### PR TITLE
lock python and pip package versions

### DIFF
--- a/.github/workflows/test_colab.yml
+++ b/.github/workflows/test_colab.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11
 
       - name: Install dependencies
-        run: pip install requests pandas google-cloud-bigquery pyarrow nbformat
+        run: pip install requests==2.31.0 pandas==2.1.1 google-cloud-bigquery==3.12.0 pyarrow==13.0.0 nbformat==5.9.2
 
       - name: Authorize Google Cloud
         uses: google-github-actions/auth@v1
@@ -88,7 +88,7 @@ jobs:
         run: |
           for nb in part1_prerequisites part2_searching_basics part3_exploring_cohorts; do
             docker run -d --name colab -v "$(pwd):/content" -e GOOGLE_APPLICATION_CREDENTIALS="${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" imagingdatacommons/idc-testing-colab:latest
-            docker exec -t colab /bin/bash -c "pip install papermill"
+            docker exec -t colab /bin/bash -c "pip install papermill==2.4.0"
             docker exec -t colab /bin/bash -c "set -o xtrace && set -o errexit && set -o pipefail && set -o nounset && set +o errexit && cd content/ && papermill /content/notebooks/getting_started/${nb}.ipynb /content/test/outputs/${nb}_papermill_output.ipynb && set -o errexit && ls -A"
             #docker exec -t colab /bin/bash -c "jupyter nbconvert --to html --ExtractOutputPreprocessor.enabled=False /content/test/outputs/output_${nb}.ipynb"
             docker stop colab

--- a/test/outputs/part1_prerequisites_papermill_output.ipynb
+++ b/test/outputs/part1_prerequisites_papermill_output.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9c6484f5",
+   "id": "2a528aee",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github",
     "papermill": {
-     "duration": 0.00499,
-     "end_time": "2023-10-26T14:57:16.236023",
+     "duration": 0.004734,
+     "end_time": "2023-10-27T01:51:04.113145",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.231033",
+     "start_time": "2023-10-27T01:51:04.108411",
      "status": "completed"
     },
     "tags": []
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cd47ccc",
+   "id": "631490a4",
    "metadata": {
     "id": "KmXfYFZtja2F",
     "papermill": {
-     "duration": 0.003178,
-     "end_time": "2023-10-26T14:57:16.242903",
+     "duration": 0.002459,
+     "end_time": "2023-10-27T01:51:04.119024",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.239725",
+     "start_time": "2023-10-27T01:51:04.116565",
      "status": "completed"
     },
     "tags": []
@@ -51,14 +51,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a86eeb5e",
+   "id": "bf9025a7",
    "metadata": {
     "id": "r9udGNfCodXM",
     "papermill": {
-     "duration": 0.003304,
-     "end_time": "2023-10-26T14:57:16.249152",
+     "duration": 0.002674,
+     "end_time": "2023-10-27T01:51:04.124111",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.245848",
+     "start_time": "2023-10-27T01:51:04.121437",
      "status": "completed"
     },
     "tags": []
@@ -71,14 +71,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6857611b",
+   "id": "cde1d874",
    "metadata": {
     "id": "EEp3BOZCodXM",
     "papermill": {
-     "duration": 0.002751,
-     "end_time": "2023-10-26T14:57:16.254692",
+     "duration": 0.002337,
+     "end_time": "2023-10-27T01:51:04.129010",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.251941",
+     "start_time": "2023-10-27T01:51:04.126673",
      "status": "completed"
     },
     "tags": []
@@ -91,14 +91,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa94b2fc",
+   "id": "1155770d",
    "metadata": {
     "id": "s9aAvHBaodXN",
     "papermill": {
-     "duration": 0.002915,
-     "end_time": "2023-10-26T14:57:16.260512",
+     "duration": 0.002413,
+     "end_time": "2023-10-27T01:51:04.133796",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.257597",
+     "start_time": "2023-10-27T01:51:04.131383",
      "status": "completed"
     },
     "tags": []
@@ -115,14 +115,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c678f8f",
+   "id": "f0d6c57e",
    "metadata": {
     "id": "DJkpgDZoodXN",
     "papermill": {
-     "duration": 0.002844,
-     "end_time": "2023-10-26T14:57:16.266321",
+     "duration": 0.002453,
+     "end_time": "2023-10-27T01:51:04.139027",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.263477",
+     "start_time": "2023-10-27T01:51:04.136574",
      "status": "completed"
     },
     "tags": []
@@ -139,14 +139,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53f726b6",
+   "id": "34ab76b2",
    "metadata": {
     "id": "bF4n45wRodXO",
     "papermill": {
-     "duration": 0.002896,
-     "end_time": "2023-10-26T14:57:16.272169",
+     "duration": 0.002768,
+     "end_time": "2023-10-27T01:51:04.144000",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.269273",
+     "start_time": "2023-10-27T01:51:04.141232",
      "status": "completed"
     },
     "tags": []
@@ -161,14 +161,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc8b9ac0",
+   "id": "4b40b1bd",
    "metadata": {
     "id": "PPIHDykYodXO",
     "papermill": {
-     "duration": 0.002937,
-     "end_time": "2023-10-26T14:57:16.279665",
+     "duration": 0.002295,
+     "end_time": "2023-10-27T01:51:04.149254",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.276728",
+     "start_time": "2023-10-27T01:51:04.146959",
      "status": "completed"
     },
     "tags": []
@@ -196,21 +196,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6de48f56",
+   "id": "ab9a5e84",
    "metadata": {
     "cellView": "form",
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:16.286812Z",
-     "iopub.status.busy": "2023-10-26T14:57:16.286472Z",
-     "iopub.status.idle": "2023-10-26T14:57:16.291093Z",
-     "shell.execute_reply": "2023-10-26T14:57:16.290144Z"
+     "iopub.execute_input": "2023-10-27T01:51:04.156378Z",
+     "iopub.status.busy": "2023-10-27T01:51:04.155952Z",
+     "iopub.status.idle": "2023-10-27T01:51:04.160039Z",
+     "shell.execute_reply": "2023-10-27T01:51:04.159370Z"
     },
     "id": "SJ29fuYyodXP",
     "papermill": {
-     "duration": 0.010396,
-     "end_time": "2023-10-26T14:57:16.292922",
+     "duration": 0.010457,
+     "end_time": "2023-10-27T01:51:04.162058",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.282526",
+     "start_time": "2023-10-27T01:51:04.151601",
      "status": "completed"
     },
     "tags": [],
@@ -235,14 +235,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e277061",
+   "id": "8fa45b4e",
    "metadata": {
     "id": "Ty5tneoqodXQ",
     "papermill": {
-     "duration": 0.002753,
-     "end_time": "2023-10-26T14:57:16.298454",
+     "duration": 0.002567,
+     "end_time": "2023-10-27T01:51:04.167158",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.295701",
+     "start_time": "2023-10-27T01:51:04.164591",
      "status": "completed"
     },
     "tags": []
@@ -275,14 +275,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7f2a40c",
+   "id": "1b9eeee6",
    "metadata": {
     "id": "-hM3oLGFodXQ",
     "papermill": {
-     "duration": 0.002626,
-     "end_time": "2023-10-26T14:57:16.304651",
+     "duration": 0.002516,
+     "end_time": "2023-10-27T01:51:04.173117",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.302025",
+     "start_time": "2023-10-27T01:51:04.170601",
      "status": "completed"
     },
     "tags": []
@@ -296,20 +296,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "71498980",
+   "id": "15f0fd62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:16.312079Z",
-     "iopub.status.busy": "2023-10-26T14:57:16.311623Z",
-     "iopub.status.idle": "2023-10-26T14:57:20.857712Z",
-     "shell.execute_reply": "2023-10-26T14:57:20.856798Z"
+     "iopub.execute_input": "2023-10-27T01:51:04.179400Z",
+     "iopub.status.busy": "2023-10-27T01:51:04.179160Z",
+     "iopub.status.idle": "2023-10-27T01:51:08.384212Z",
+     "shell.execute_reply": "2023-10-27T01:51:08.383281Z"
     },
     "id": "Ab9RyG2EodXR",
     "papermill": {
-     "duration": 4.552875,
-     "end_time": "2023-10-26T14:57:20.860432",
+     "duration": 4.210311,
+     "end_time": "2023-10-27T01:51:08.386090",
      "exception": false,
-     "start_time": "2023-10-26T14:57:16.307557",
+     "start_time": "2023-10-27T01:51:04.175779",
      "status": "completed"
     },
     "tags": [],
@@ -321,7 +321,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ed966bfe36d4e20ad5d8115a32ed00a",
+       "model_id": "9cc55bc26ee7417a9f67cce35a052856",
        "version_major": 2,
        "version_minor": 0
       },
@@ -335,7 +335,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e2aad15ef1584a0e81dd2f2584eb4879",
+       "model_id": "8dbb5e7cd0274208b81cc7341d1880c4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -350,7 +350,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-be4fcbe6-8d2a-4777-a204-e68eccfb6b54\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -383,7 +383,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-be4fcbe6-8d2a-4777-a204-e68eccfb6b54')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -435,12 +435,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-be4fcbe6-8d2a-4777-a204-e68eccfb6b54 button.colab-df-convert');\n",
+       "        document.querySelector('#df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-be4fcbe6-8d2a-4777-a204-e68eccfb6b54');\n",
+       "        const element = document.querySelector('#df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -482,14 +482,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "455a4704",
+   "id": "c60659ef",
    "metadata": {
     "id": "nxsmxh0WodXR",
     "papermill": {
-     "duration": 0.003856,
-     "end_time": "2023-10-26T14:57:20.868423",
+     "duration": 0.003519,
+     "end_time": "2023-10-27T01:51:08.393149",
      "exception": false,
-     "start_time": "2023-10-26T14:57:20.864567",
+     "start_time": "2023-10-27T01:51:08.389630",
      "status": "completed"
     },
     "tags": []
@@ -500,14 +500,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c27cb077",
+   "id": "7c24226c",
    "metadata": {
     "id": "zCabXb6kodXR",
     "papermill": {
-     "duration": 0.00364,
-     "end_time": "2023-10-26T14:57:20.875704",
+     "duration": 0.003085,
+     "end_time": "2023-10-27T01:51:08.399449",
      "exception": false,
-     "start_time": "2023-10-26T14:57:20.872064",
+     "start_time": "2023-10-27T01:51:08.396364",
      "status": "completed"
     },
     "tags": []
@@ -520,14 +520,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4aa54084",
+   "id": "8a3e1672",
    "metadata": {
     "id": "us4PODapodXR",
     "papermill": {
-     "duration": 0.003511,
-     "end_time": "2023-10-26T14:57:20.883224",
+     "duration": 0.003084,
+     "end_time": "2023-10-27T01:51:08.405512",
      "exception": false,
-     "start_time": "2023-10-26T14:57:20.879713",
+     "start_time": "2023-10-27T01:51:08.402428",
      "status": "completed"
     },
     "tags": []
@@ -567,125 +567,205 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.928839,
-   "end_time": "2023-10-26T14:57:21.395143",
+   "duration": 7.306505,
+   "end_time": "2023-10-27T01:51:09.746559",
    "environment_variables": {},
    "exception": null,
    "input_path": "/content/notebooks/getting_started/part1_prerequisites.ipynb",
    "output_path": "/content/test/outputs/part1_prerequisites_papermill_output.ipynb",
    "parameters": {},
-   "start_time": "2023-10-26T14:57:14.466304",
+   "start_time": "2023-10-27T01:51:02.440054",
    "version": "2.4.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "088801dd96c64c4b85da24626da1a0f3": {
+     "0dc0e893daaa463aacaf3e99a03753ce": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "32cec5cc4e7e4a76aabb2371c0f36bd1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "379945987a2a482aa19b11383e53a29c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
+       "_model_name": "DescriptionStyleModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "1.2.0",
        "_view_name": "StyleView",
-       "bar_color": null,
        "description_width": ""
       }
      },
-     "0b11c7fde8ec42848cffc0cb2ef9fc88": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2218916bd2ea47d7a699f538fb1283bf": {
+     "4539176690cf4397a653a41aff101057": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_677cad98aed048d5b102649cb1704b39",
-       "placeholder": "​",
-       "style": "IPY_MODEL_c59101841e584c47ad8716b80bf07ee7",
-       "value": "Job ID 55eb24e0-cec1-47fb-af89-2501dd1bff68 successfully executed: 100%"
-      }
-     },
-     "29261cf9eeb24c2dab757633b4120f86": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
+       "_model_name": "DescriptionStyleModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "1.2.0",
        "_view_name": "StyleView",
-       "bar_color": null,
        "description_width": ""
       }
      },
-     "3145c54aaf40458eb76d6988528b6e7d": {
+     "45bb54b281bb4e2f93df003009058f20": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_ad453e524125463699bb580d475c3966",
+       "placeholder": "​",
+       "style": "IPY_MODEL_379945987a2a482aa19b11383e53a29c",
+       "value": "Job ID d761b26c-5823-4981-ba3b-f704a077c085 successfully executed: 100%"
+      }
+     },
+     "468896353be747a8ac22972000c1378e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "481e9bc1d34a4ef695f46c590ff410ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "49c4d1ff79c84fc597f3591a9edc6891": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -737,7 +817,83 @@
        "width": null
       }
      },
-     "34be086b13cc44e2ab86cf32765abc69": {
+     "4a3be32ae2114fd1be3b723f82545627": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "56d5efbe5ac14e118b9b451ae64d634b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_4a3be32ae2114fd1be3b723f82545627",
+       "max": 1.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_a43a73dc08e54c5590324047da8c8571",
+       "value": 1.0
+      }
+     },
+     "8836fb933815489b8ae1cc832cc97d8c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -752,13 +908,35 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_3145c54aaf40458eb76d6988528b6e7d",
+       "layout": "IPY_MODEL_32cec5cc4e7e4a76aabb2371c0f36bd1",
        "placeholder": "​",
-       "style": "IPY_MODEL_aab0ad7789214e5287634264babade77",
+       "style": "IPY_MODEL_468896353be747a8ac22972000c1378e",
        "value": ""
       }
      },
-     "4bb26a8f2af44635a3c3c2b1685d665c": {
+     "8dbb5e7cd0274208b81cc7341d1880c4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_9f9c2107ff7744cb924e5cbf2afa710c",
+        "IPY_MODEL_a54a7bef832e476ba8730dd575b08053",
+        "IPY_MODEL_8836fb933815489b8ae1cc832cc97d8c"
+       ],
+       "layout": "IPY_MODEL_d8cb79d4301e4a69b5b9c7726f40b851"
+      }
+     },
+     "91a9513a96c443c082f0e6e1cfecd5e9": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -810,7 +988,7 @@
        "width": null
       }
      },
-     "4c14530134244d1fb67348a3cda85cac": {
+     "9ca67f8a51d64beb9f8015df3de04dd3": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -862,59 +1040,29 @@
        "width": null
       }
      },
-     "4d7666a4ceeb462cbf64e91e5d97b153": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
+     "9cc55bc26ee7417a9f67cce35a052856": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
       "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HBoxModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_45bb54b281bb4e2f93df003009058f20",
+        "IPY_MODEL_56d5efbe5ac14e118b9b451ae64d634b",
+        "IPY_MODEL_9d227b8247924aad99b80b3683790b8e"
+       ],
+       "layout": "IPY_MODEL_49c4d1ff79c84fc597f3591a9edc6891"
       }
      },
-     "53d57dbd65ff42dd99c30736aef6890a": {
+     "9d227b8247924aad99b80b3683790b8e": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -929,117 +1077,13 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_0b11c7fde8ec42848cffc0cb2ef9fc88",
+       "layout": "IPY_MODEL_91a9513a96c443c082f0e6e1cfecd5e9",
        "placeholder": "​",
-       "style": "IPY_MODEL_baec68e7eb5544d693050281ee69819a",
+       "style": "IPY_MODEL_481e9bc1d34a4ef695f46c590ff410ad",
        "value": ""
       }
      },
-     "677cad98aed048d5b102649cb1704b39": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "6f824ef6b8774b7b918d311d5b0f24de": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "736a5bdb14d143379cc4bd25b8f9d1b4": {
+     "9f9c2107ff7744cb924e5cbf2afa710c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -1054,35 +1098,53 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_6f824ef6b8774b7b918d311d5b0f24de",
+       "layout": "IPY_MODEL_9ca67f8a51d64beb9f8015df3de04dd3",
        "placeholder": "​",
-       "style": "IPY_MODEL_8a32803932834d83a91f92b9c0af9aa9",
+       "style": "IPY_MODEL_4539176690cf4397a653a41aff101057",
        "value": "Downloading: 100%"
       }
      },
-     "7ed966bfe36d4e20ad5d8115a32ed00a": {
+     "a43a73dc08e54c5590324047da8c8571": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "a54a7bef832e476ba8730dd575b08053": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
       "state": {
        "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "HBoxModel",
+       "_model_name": "FloatProgressModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "1.5.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_2218916bd2ea47d7a699f538fb1283bf",
-        "IPY_MODEL_c49ed36ed88e4c19949b6acb54b51f96",
-        "IPY_MODEL_34be086b13cc44e2ab86cf32765abc69"
-       ],
-       "layout": "IPY_MODEL_4d7666a4ceeb462cbf64e91e5d97b153"
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_0dc0e893daaa463aacaf3e99a03753ce",
+       "max": 1.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_db79168503334aa28ed06a12bd0510d0",
+       "value": 1.0
       }
      },
-     "81f29f46a99344c6a797e625eaf12d78": {
+     "ad453e524125463699bb580d475c3966": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -1134,134 +1196,72 @@
        "width": null
       }
      },
-     "8a32803932834d83a91f92b9c0af9aa9": {
+     "d8cb79d4301e4a69b5b9c7726f40b851": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "db79168503334aa28ed06a12bd0510d0": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
+      "model_name": "ProgressStyleModel",
       "state": {
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
+       "_model_name": "ProgressStyleModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "1.2.0",
        "_view_name": "StyleView",
+       "bar_color": null,
        "description_width": ""
-      }
-     },
-     "aab0ad7789214e5287634264babade77": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "baec68e7eb5544d693050281ee69819a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "c49ed36ed88e4c19949b6acb54b51f96": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_4c14530134244d1fb67348a3cda85cac",
-       "max": 1.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_29261cf9eeb24c2dab757633b4120f86",
-       "value": 1.0
-      }
-     },
-     "c59101841e584c47ad8716b80bf07ee7": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "e2aad15ef1584a0e81dd2f2584eb4879": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_736a5bdb14d143379cc4bd25b8f9d1b4",
-        "IPY_MODEL_f8bd0fc5bf4044f4bfd52026511b8485",
-        "IPY_MODEL_53d57dbd65ff42dd99c30736aef6890a"
-       ],
-       "layout": "IPY_MODEL_4bb26a8f2af44635a3c3c2b1685d665c"
-      }
-     },
-     "f8bd0fc5bf4044f4bfd52026511b8485": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_81f29f46a99344c6a797e625eaf12d78",
-       "max": 1.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_088801dd96c64c4b85da24626da1a0f3",
-       "value": 1.0
       }
      }
     },

--- a/test/outputs/part1_prerequisites_papermill_output.ipynb
+++ b/test/outputs/part1_prerequisites_papermill_output.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2a528aee",
+   "id": "44f4df44",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github",
     "papermill": {
-     "duration": 0.004734,
-     "end_time": "2023-10-27T01:51:04.113145",
+     "duration": 0.004398,
+     "end_time": "2023-10-27T12:41:24.034735",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.108411",
+     "start_time": "2023-10-27T12:41:24.030337",
      "status": "completed"
     },
     "tags": []
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "631490a4",
+   "id": "f0097a34",
    "metadata": {
     "id": "KmXfYFZtja2F",
     "papermill": {
-     "duration": 0.002459,
-     "end_time": "2023-10-27T01:51:04.119024",
+     "duration": 0.002795,
+     "end_time": "2023-10-27T12:41:24.040235",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.116565",
+     "start_time": "2023-10-27T12:41:24.037440",
      "status": "completed"
     },
     "tags": []
@@ -51,14 +51,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf9025a7",
+   "id": "a9f14f95",
    "metadata": {
     "id": "r9udGNfCodXM",
     "papermill": {
-     "duration": 0.002674,
-     "end_time": "2023-10-27T01:51:04.124111",
+     "duration": 0.002298,
+     "end_time": "2023-10-27T12:41:24.044891",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.121437",
+     "start_time": "2023-10-27T12:41:24.042593",
      "status": "completed"
     },
     "tags": []
@@ -71,14 +71,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cde1d874",
+   "id": "6d4c145a",
    "metadata": {
     "id": "EEp3BOZCodXM",
     "papermill": {
-     "duration": 0.002337,
-     "end_time": "2023-10-27T01:51:04.129010",
+     "duration": 0.002218,
+     "end_time": "2023-10-27T12:41:24.049367",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.126673",
+     "start_time": "2023-10-27T12:41:24.047149",
      "status": "completed"
     },
     "tags": []
@@ -91,14 +91,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1155770d",
+   "id": "4346236b",
    "metadata": {
     "id": "s9aAvHBaodXN",
     "papermill": {
-     "duration": 0.002413,
-     "end_time": "2023-10-27T01:51:04.133796",
+     "duration": 0.002207,
+     "end_time": "2023-10-27T12:41:24.053864",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.131383",
+     "start_time": "2023-10-27T12:41:24.051657",
      "status": "completed"
     },
     "tags": []
@@ -115,14 +115,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0d6c57e",
+   "id": "e8530c5f",
    "metadata": {
     "id": "DJkpgDZoodXN",
     "papermill": {
-     "duration": 0.002453,
-     "end_time": "2023-10-27T01:51:04.139027",
+     "duration": 0.002219,
+     "end_time": "2023-10-27T12:41:24.058365",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.136574",
+     "start_time": "2023-10-27T12:41:24.056146",
      "status": "completed"
     },
     "tags": []
@@ -139,14 +139,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34ab76b2",
+   "id": "644b7532",
    "metadata": {
     "id": "bF4n45wRodXO",
     "papermill": {
-     "duration": 0.002768,
-     "end_time": "2023-10-27T01:51:04.144000",
+     "duration": 0.00222,
+     "end_time": "2023-10-27T12:41:24.062819",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.141232",
+     "start_time": "2023-10-27T12:41:24.060599",
      "status": "completed"
     },
     "tags": []
@@ -161,14 +161,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b40b1bd",
+   "id": "0fff00ad",
    "metadata": {
     "id": "PPIHDykYodXO",
     "papermill": {
-     "duration": 0.002295,
-     "end_time": "2023-10-27T01:51:04.149254",
+     "duration": 0.00227,
+     "end_time": "2023-10-27T12:41:24.067358",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.146959",
+     "start_time": "2023-10-27T12:41:24.065088",
      "status": "completed"
     },
     "tags": []
@@ -196,21 +196,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ab9a5e84",
+   "id": "80eb5961",
    "metadata": {
     "cellView": "form",
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:04.156378Z",
-     "iopub.status.busy": "2023-10-27T01:51:04.155952Z",
-     "iopub.status.idle": "2023-10-27T01:51:04.160039Z",
-     "shell.execute_reply": "2023-10-27T01:51:04.159370Z"
+     "iopub.execute_input": "2023-10-27T12:41:24.073760Z",
+     "iopub.status.busy": "2023-10-27T12:41:24.073422Z",
+     "iopub.status.idle": "2023-10-27T12:41:24.076965Z",
+     "shell.execute_reply": "2023-10-27T12:41:24.076361Z"
     },
     "id": "SJ29fuYyodXP",
     "papermill": {
-     "duration": 0.010457,
-     "end_time": "2023-10-27T01:51:04.162058",
+     "duration": 0.008816,
+     "end_time": "2023-10-27T12:41:24.078597",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.151601",
+     "start_time": "2023-10-27T12:41:24.069781",
      "status": "completed"
     },
     "tags": [],
@@ -235,14 +235,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fa45b4e",
+   "id": "21807d15",
    "metadata": {
     "id": "Ty5tneoqodXQ",
     "papermill": {
-     "duration": 0.002567,
-     "end_time": "2023-10-27T01:51:04.167158",
+     "duration": 0.002309,
+     "end_time": "2023-10-27T12:41:24.083189",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.164591",
+     "start_time": "2023-10-27T12:41:24.080880",
      "status": "completed"
     },
     "tags": []
@@ -275,14 +275,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b9eeee6",
+   "id": "8bb11665",
    "metadata": {
     "id": "-hM3oLGFodXQ",
     "papermill": {
-     "duration": 0.002516,
-     "end_time": "2023-10-27T01:51:04.173117",
+     "duration": 0.002252,
+     "end_time": "2023-10-27T12:41:24.088535",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.170601",
+     "start_time": "2023-10-27T12:41:24.086283",
      "status": "completed"
     },
     "tags": []
@@ -296,20 +296,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "15f0fd62",
+   "id": "b85c1115",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:04.179400Z",
-     "iopub.status.busy": "2023-10-27T01:51:04.179160Z",
-     "iopub.status.idle": "2023-10-27T01:51:08.384212Z",
-     "shell.execute_reply": "2023-10-27T01:51:08.383281Z"
+     "iopub.execute_input": "2023-10-27T12:41:24.094318Z",
+     "iopub.status.busy": "2023-10-27T12:41:24.094060Z",
+     "iopub.status.idle": "2023-10-27T12:41:28.446186Z",
+     "shell.execute_reply": "2023-10-27T12:41:28.445494Z"
     },
     "id": "Ab9RyG2EodXR",
     "papermill": {
-     "duration": 4.210311,
-     "end_time": "2023-10-27T01:51:08.386090",
+     "duration": 4.356837,
+     "end_time": "2023-10-27T12:41:28.447703",
      "exception": false,
-     "start_time": "2023-10-27T01:51:04.175779",
+     "start_time": "2023-10-27T12:41:24.090866",
      "status": "completed"
     },
     "tags": [],
@@ -321,7 +321,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9cc55bc26ee7417a9f67cce35a052856",
+       "model_id": "3dc927e3ea354f718f003ef3eff58fdf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -335,7 +335,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8dbb5e7cd0274208b81cc7341d1880c4",
+       "model_id": "897d7433633a4df69cd01aadc25a26d9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -350,7 +350,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-a524eab5-19ce-455c-aa5c-50487eec790e\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -383,7 +383,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-a524eab5-19ce-455c-aa5c-50487eec790e')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -435,12 +435,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e button.colab-df-convert');\n",
+       "        document.querySelector('#df-a524eab5-19ce-455c-aa5c-50487eec790e button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-361c6f0e-c3f7-4ee1-a682-5ed55a7bcf0e');\n",
+       "        const element = document.querySelector('#df-a524eab5-19ce-455c-aa5c-50487eec790e');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -482,14 +482,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c60659ef",
+   "id": "02c832b8",
    "metadata": {
     "id": "nxsmxh0WodXR",
     "papermill": {
-     "duration": 0.003519,
-     "end_time": "2023-10-27T01:51:08.393149",
+     "duration": 0.003282,
+     "end_time": "2023-10-27T12:41:28.454224",
      "exception": false,
-     "start_time": "2023-10-27T01:51:08.389630",
+     "start_time": "2023-10-27T12:41:28.450942",
      "status": "completed"
     },
     "tags": []
@@ -500,14 +500,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c24226c",
+   "id": "a56cf5fe",
    "metadata": {
     "id": "zCabXb6kodXR",
     "papermill": {
-     "duration": 0.003085,
-     "end_time": "2023-10-27T01:51:08.399449",
+     "duration": 0.002766,
+     "end_time": "2023-10-27T12:41:28.459827",
      "exception": false,
-     "start_time": "2023-10-27T01:51:08.396364",
+     "start_time": "2023-10-27T12:41:28.457061",
      "status": "completed"
     },
     "tags": []
@@ -520,14 +520,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a3e1672",
+   "id": "a618ff10",
    "metadata": {
     "id": "us4PODapodXR",
     "papermill": {
-     "duration": 0.003084,
-     "end_time": "2023-10-27T01:51:08.405512",
+     "duration": 0.002784,
+     "end_time": "2023-10-27T12:41:28.465404",
      "exception": false,
-     "start_time": "2023-10-27T01:51:08.402428",
+     "start_time": "2023-10-27T12:41:28.462620",
      "status": "completed"
     },
     "tags": []
@@ -567,20 +567,20 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.306505,
-   "end_time": "2023-10-27T01:51:09.746559",
+   "duration": 7.238019,
+   "end_time": "2023-10-27T12:41:29.817411",
    "environment_variables": {},
    "exception": null,
    "input_path": "/content/notebooks/getting_started/part1_prerequisites.ipynb",
    "output_path": "/content/test/outputs/part1_prerequisites_papermill_output.ipynb",
    "parameters": {},
-   "start_time": "2023-10-27T01:51:02.440054",
+   "start_time": "2023-10-27T12:41:22.579392",
    "version": "2.4.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "0dc0e893daaa463aacaf3e99a03753ce": {
+     "11718bb7598e40719dcfac9e1fa4768b": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -632,89 +632,7 @@
        "width": null
       }
      },
-     "32cec5cc4e7e4a76aabb2371c0f36bd1": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "379945987a2a482aa19b11383e53a29c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "4539176690cf4397a653a41aff101057": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "45bb54b281bb4e2f93df003009058f20": {
+     "17c3ecbd447741f6adf29d8e80f8ed07": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -729,43 +647,13 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_ad453e524125463699bb580d475c3966",
+       "layout": "IPY_MODEL_3ffea02cb46046f5abf8356bc6445062",
        "placeholder": "​",
-       "style": "IPY_MODEL_379945987a2a482aa19b11383e53a29c",
-       "value": "Job ID d761b26c-5823-4981-ba3b-f704a077c085 successfully executed: 100%"
+       "style": "IPY_MODEL_630ee2b735e64df0b3f8d1d600e6de21",
+       "value": ""
       }
      },
-     "468896353be747a8ac22972000c1378e": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "481e9bc1d34a4ef695f46c590ff410ad": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "49c4d1ff79c84fc597f3591a9edc6891": {
+     "35dc8dc5de614c8b8310a621e848bfa7": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -817,7 +705,29 @@
        "width": null
       }
      },
-     "4a3be32ae2114fd1be3b723f82545627": {
+     "3dc927e3ea354f718f003ef3eff58fdf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_d1e53a7d0d1f4e88856a8d70d91604e2",
+        "IPY_MODEL_b57404dd64a4491982f5cd1da71b2e70",
+        "IPY_MODEL_17c3ecbd447741f6adf29d8e80f8ed07"
+       ],
+       "layout": "IPY_MODEL_35dc8dc5de614c8b8310a621e848bfa7"
+      }
+     },
+     "3ffea02cb46046f5abf8356bc6445062": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -869,7 +779,111 @@
        "width": null
       }
      },
-     "56d5efbe5ac14e118b9b451ae64d634b": {
+     "5b169c3c5dca4453a4c89fa75001071a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "5bd1de4227384ac29b05c1147a305674": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "5fbc6a4e6eaa4989a4883b0c30a7af9a": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "FloatProgressModel",
@@ -885,58 +899,45 @@
        "bar_style": "success",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_4a3be32ae2114fd1be3b723f82545627",
+       "layout": "IPY_MODEL_5b169c3c5dca4453a4c89fa75001071a",
        "max": 1.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_a43a73dc08e54c5590324047da8c8571",
+       "style": "IPY_MODEL_8084c49ec1e5408d95f3e8d5bd043679",
        "value": 1.0
       }
      },
-     "8836fb933815489b8ae1cc832cc97d8c": {
+     "630ee2b735e64df0b3f8d1d600e6de21": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
+       "_model_name": "DescriptionStyleModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_32cec5cc4e7e4a76aabb2371c0f36bd1",
-       "placeholder": "​",
-       "style": "IPY_MODEL_468896353be747a8ac22972000c1378e",
-       "value": ""
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
       }
      },
-     "8dbb5e7cd0274208b81cc7341d1880c4": {
+     "74b7a1d679c6420690ad734a2ef9e76b": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "HBoxModel",
+       "_model_name": "DescriptionStyleModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_9f9c2107ff7744cb924e5cbf2afa710c",
-        "IPY_MODEL_a54a7bef832e476ba8730dd575b08053",
-        "IPY_MODEL_8836fb933815489b8ae1cc832cc97d8c"
-       ],
-       "layout": "IPY_MODEL_d8cb79d4301e4a69b5b9c7726f40b851"
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
       }
      },
-     "91a9513a96c443c082f0e6e1cfecd5e9": {
+     "7c0dca9c50c34a7d94e73ba4534a03a9": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -988,7 +989,7 @@
        "width": null
       }
      },
-     "9ca67f8a51d64beb9f8015df3de04dd3": {
+     "7e4874c221e5457f8530c96faf448bc9": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -1040,7 +1041,38 @@
        "width": null
       }
      },
-     "9cc55bc26ee7417a9f67cce35a052856": {
+     "8084c49ec1e5408d95f3e8d5bd043679": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "892f2b198d4546bbacfcb7a594fbe9e0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "897d7433633a4df69cd01aadc25a26d9": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
@@ -1055,14 +1087,106 @@
        "_view_name": "HBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_45bb54b281bb4e2f93df003009058f20",
-        "IPY_MODEL_56d5efbe5ac14e118b9b451ae64d634b",
-        "IPY_MODEL_9d227b8247924aad99b80b3683790b8e"
+        "IPY_MODEL_cb8b97ccb2ed4fbeb2bfb6b9527af3fb",
+        "IPY_MODEL_5fbc6a4e6eaa4989a4883b0c30a7af9a",
+        "IPY_MODEL_bee6728ebf46488bbd05f7e9fb0fa74c"
        ],
-       "layout": "IPY_MODEL_49c4d1ff79c84fc597f3591a9edc6891"
+       "layout": "IPY_MODEL_5bd1de4227384ac29b05c1147a305674"
       }
      },
-     "9d227b8247924aad99b80b3683790b8e": {
+     "b57404dd64a4491982f5cd1da71b2e70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_7e4874c221e5457f8530c96faf448bc9",
+       "max": 1.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_b86848237d8b4219a83ff94ad50157b7",
+       "value": 1.0
+      }
+     },
+     "b86848237d8b4219a83ff94ad50157b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "be27a7ec69d641ff8800d5931b9e872d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "bee6728ebf46488bbd05f7e9fb0fa74c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -1077,13 +1201,28 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_91a9513a96c443c082f0e6e1cfecd5e9",
+       "layout": "IPY_MODEL_be27a7ec69d641ff8800d5931b9e872d",
        "placeholder": "​",
-       "style": "IPY_MODEL_481e9bc1d34a4ef695f46c590ff410ad",
+       "style": "IPY_MODEL_74b7a1d679c6420690ad734a2ef9e76b",
        "value": ""
       }
      },
-     "9f9c2107ff7744cb924e5cbf2afa710c": {
+     "c411105db8f84b9595c84ef7b550a6ca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "cb8b97ccb2ed4fbeb2bfb6b9527af3fb": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -1098,170 +1237,31 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_9ca67f8a51d64beb9f8015df3de04dd3",
+       "layout": "IPY_MODEL_7c0dca9c50c34a7d94e73ba4534a03a9",
        "placeholder": "​",
-       "style": "IPY_MODEL_4539176690cf4397a653a41aff101057",
+       "style": "IPY_MODEL_892f2b198d4546bbacfcb7a594fbe9e0",
        "value": "Downloading: 100%"
       }
      },
-     "a43a73dc08e54c5590324047da8c8571": {
+     "d1e53a7d0d1f4e88856a8d70d91604e2": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "a54a7bef832e476ba8730dd575b08053": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
+      "model_name": "HTMLModel",
       "state": {
        "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "FloatProgressModel",
+       "_model_name": "HTMLModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "1.5.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
+       "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_0dc0e893daaa463aacaf3e99a03753ce",
-       "max": 1.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_db79168503334aa28ed06a12bd0510d0",
-       "value": 1.0
-      }
-     },
-     "ad453e524125463699bb580d475c3966": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "d8cb79d4301e4a69b5b9c7726f40b851": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "db79168503334aa28ed06a12bd0510d0": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
+       "layout": "IPY_MODEL_11718bb7598e40719dcfac9e1fa4768b",
+       "placeholder": "​",
+       "style": "IPY_MODEL_c411105db8f84b9595c84ef7b550a6ca",
+       "value": "Job ID b714fad3-c1c1-44e7-bc44-fe6238eb6f10 successfully executed: 100%"
       }
      }
     },

--- a/test/outputs/part2_searching_basics_papermill_output.ipynb
+++ b/test/outputs/part2_searching_basics_papermill_output.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cc51795b",
+   "id": "d9da63a0",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github",
     "papermill": {
-     "duration": 0.00588,
-     "end_time": "2023-10-27T01:51:19.607628",
+     "duration": 0.005963,
+     "end_time": "2023-10-27T12:41:38.699086",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.601748",
+     "start_time": "2023-10-27T12:41:38.693123",
      "status": "completed"
     },
     "tags": []
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ffc54c8",
+   "id": "ea6d4128",
    "metadata": {
     "id": "KmXfYFZtja2F",
     "papermill": {
-     "duration": 0.004624,
-     "end_time": "2023-10-27T01:51:19.617373",
+     "duration": 0.004545,
+     "end_time": "2023-10-27T12:41:38.708392",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.612749",
+     "start_time": "2023-10-27T12:41:38.703847",
      "status": "completed"
     },
     "tags": []
@@ -55,14 +55,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba0d801d",
+   "id": "39cfd5c8",
    "metadata": {
     "id": "-z3XVLAgArvo",
     "papermill": {
-     "duration": 0.004362,
-     "end_time": "2023-10-27T01:51:19.626572",
+     "duration": 0.004364,
+     "end_time": "2023-10-27T12:41:38.717161",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.622210",
+     "start_time": "2023-10-27T12:41:38.712797",
      "status": "completed"
     },
     "tags": []
@@ -75,14 +75,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f77ee299",
+   "id": "858f3180",
    "metadata": {
     "id": "a4Q-kRDW77Iy",
     "papermill": {
-     "duration": 0.004646,
-     "end_time": "2023-10-27T01:51:19.635779",
+     "duration": 0.004316,
+     "end_time": "2023-10-27T12:41:38.725919",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.631133",
+     "start_time": "2023-10-27T12:41:38.721603",
      "status": "completed"
     },
     "tags": []
@@ -100,21 +100,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6a03bc4f",
+   "id": "60250925",
    "metadata": {
     "cellView": "form",
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:19.647680Z",
-     "iopub.status.busy": "2023-10-27T01:51:19.647331Z",
-     "iopub.status.idle": "2023-10-27T01:51:19.651416Z",
-     "shell.execute_reply": "2023-10-27T01:51:19.650717Z"
+     "iopub.execute_input": "2023-10-27T12:41:38.736968Z",
+     "iopub.status.busy": "2023-10-27T12:41:38.736636Z",
+     "iopub.status.idle": "2023-10-27T12:41:38.740443Z",
+     "shell.execute_reply": "2023-10-27T12:41:38.739710Z"
     },
     "id": "bDGChJBK9ooq",
     "papermill": {
-     "duration": 0.012785,
-     "end_time": "2023-10-27T01:51:19.653065",
+     "duration": 0.011701,
+     "end_time": "2023-10-27T12:41:38.741982",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.640280",
+     "start_time": "2023-10-27T12:41:38.730281",
      "status": "completed"
     },
     "tags": []
@@ -136,14 +136,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d11bbe5",
+   "id": "b8fc52ef",
    "metadata": {
     "id": "zrbT7voq7yU5",
     "papermill": {
-     "duration": 0.004801,
-     "end_time": "2023-10-27T01:51:19.662488",
+     "duration": 0.004423,
+     "end_time": "2023-10-27T12:41:38.750818",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.657687",
+     "start_time": "2023-10-27T12:41:38.746395",
      "status": "completed"
     },
     "tags": []
@@ -158,14 +158,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "276dda5e",
+   "id": "dd57f52d",
    "metadata": {
     "id": "kZMMjky1898-",
     "papermill": {
-     "duration": 0.004636,
-     "end_time": "2023-10-27T01:51:19.671948",
+     "duration": 0.004419,
+     "end_time": "2023-10-27T12:41:38.759650",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.667312",
+     "start_time": "2023-10-27T12:41:38.755231",
      "status": "completed"
     },
     "tags": []
@@ -194,14 +194,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08d0effd",
+   "id": "24f469f1",
    "metadata": {
     "id": "pYEiJZYy_oZW",
     "papermill": {
-     "duration": 0.004537,
-     "end_time": "2023-10-27T01:51:19.681203",
+     "duration": 0.004358,
+     "end_time": "2023-10-27T12:41:38.768450",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.676666",
+     "start_time": "2023-10-27T12:41:38.764092",
      "status": "completed"
     },
     "tags": []
@@ -234,14 +234,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b69b20af",
+   "id": "a736f0ee",
    "metadata": {
     "id": "Qke1owafZiyp",
     "papermill": {
-     "duration": 0.005249,
-     "end_time": "2023-10-27T01:51:19.691519",
+     "duration": 0.004392,
+     "end_time": "2023-10-27T12:41:38.777229",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.686270",
+     "start_time": "2023-10-27T12:41:38.772837",
      "status": "completed"
     },
     "tags": []
@@ -268,14 +268,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "397d1ca1",
+   "id": "bea5badb",
    "metadata": {
     "id": "9gE4aq0NLizR",
     "papermill": {
-     "duration": 0.004657,
-     "end_time": "2023-10-27T01:51:19.700956",
+     "duration": 0.004348,
+     "end_time": "2023-10-27T12:41:38.785957",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.696299",
+     "start_time": "2023-10-27T12:41:38.781609",
      "status": "completed"
     },
     "tags": []
@@ -293,20 +293,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ab81f4e9",
+   "id": "1e2c7f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:19.712204Z",
-     "iopub.status.busy": "2023-10-27T01:51:19.711753Z",
-     "iopub.status.idle": "2023-10-27T01:51:23.514448Z",
-     "shell.execute_reply": "2023-10-27T01:51:23.513473Z"
+     "iopub.execute_input": "2023-10-27T12:41:38.796294Z",
+     "iopub.status.busy": "2023-10-27T12:41:38.795965Z",
+     "iopub.status.idle": "2023-10-27T12:41:42.877734Z",
+     "shell.execute_reply": "2023-10-27T12:41:42.876973Z"
     },
     "id": "hfoS7obINKO7",
     "papermill": {
-     "duration": 3.810373,
-     "end_time": "2023-10-27T01:51:23.516128",
+     "duration": 4.088968,
+     "end_time": "2023-10-27T12:41:42.879390",
      "exception": false,
-     "start_time": "2023-10-27T01:51:19.705755",
+     "start_time": "2023-10-27T12:41:38.790422",
      "status": "completed"
     },
     "tags": []
@@ -316,7 +316,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-610f68f8-c5ff-47e0-b0d8-f126a081b573\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -390,7 +390,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-610f68f8-c5ff-47e0-b0d8-f126a081b573')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -442,12 +442,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19 button.colab-df-convert');\n",
+       "        document.querySelector('#df-610f68f8-c5ff-47e0-b0d8-f126a081b573 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19');\n",
+       "        const element = document.querySelector('#df-610f68f8-c5ff-47e0-b0d8-f126a081b573');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -514,14 +514,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccc4b88d",
+   "id": "ce00628f",
    "metadata": {
     "id": "7ofFg6oaNpHw",
     "papermill": {
-     "duration": 0.00523,
-     "end_time": "2023-10-27T01:51:23.527192",
+     "duration": 0.005139,
+     "end_time": "2023-10-27T12:41:42.889644",
      "exception": false,
-     "start_time": "2023-10-27T01:51:23.521962",
+     "start_time": "2023-10-27T12:41:42.884505",
      "status": "completed"
     },
     "tags": []
@@ -541,14 +541,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4941c4f8",
+   "id": "ec9cb23a",
    "metadata": {
     "id": "3kkHUgqaP2tl",
     "papermill": {
-     "duration": 0.005058,
-     "end_time": "2023-10-27T01:51:23.537588",
+     "duration": 0.004765,
+     "end_time": "2023-10-27T12:41:42.899269",
      "exception": false,
-     "start_time": "2023-10-27T01:51:23.532530",
+     "start_time": "2023-10-27T12:41:42.894504",
      "status": "completed"
     },
     "tags": []
@@ -564,20 +564,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b909d018",
+   "id": "01f0aeef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:23.549813Z",
-     "iopub.status.busy": "2023-10-27T01:51:23.549434Z",
-     "iopub.status.idle": "2023-10-27T01:51:26.741795Z",
-     "shell.execute_reply": "2023-10-27T01:51:26.740943Z"
+     "iopub.execute_input": "2023-10-27T12:41:42.910392Z",
+     "iopub.status.busy": "2023-10-27T12:41:42.909922Z",
+     "iopub.status.idle": "2023-10-27T12:41:45.832517Z",
+     "shell.execute_reply": "2023-10-27T12:41:45.831811Z"
     },
     "id": "5w9956q-P1YS",
     "papermill": {
-     "duration": 3.200498,
-     "end_time": "2023-10-27T01:51:26.743558",
+     "duration": 2.930247,
+     "end_time": "2023-10-27T12:41:45.834205",
      "exception": false,
-     "start_time": "2023-10-27T01:51:23.543060",
+     "start_time": "2023-10-27T12:41:42.903958",
      "status": "completed"
     },
     "tags": []
@@ -587,7 +587,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-d06754fa-db0b-427e-9b53-8ebd86115896\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-aecd2b8a-b274-4ef5-9a54-882f67da58a0\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -788,7 +788,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-d06754fa-db0b-427e-9b53-8ebd86115896')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-aecd2b8a-b274-4ef5-9a54-882f67da58a0')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -840,12 +840,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-d06754fa-db0b-427e-9b53-8ebd86115896 button.colab-df-convert');\n",
+       "        document.querySelector('#df-aecd2b8a-b274-4ef5-9a54-882f67da58a0 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-d06754fa-db0b-427e-9b53-8ebd86115896');\n",
+       "        const element = document.querySelector('#df-aecd2b8a-b274-4ef5-9a54-882f67da58a0');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -941,14 +941,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c877afb",
+   "id": "29e7cc64",
    "metadata": {
     "id": "h9kC-9AAQkun",
     "papermill": {
-     "duration": 0.006174,
-     "end_time": "2023-10-27T01:51:26.755778",
+     "duration": 0.005468,
+     "end_time": "2023-10-27T12:41:45.845124",
      "exception": false,
-     "start_time": "2023-10-27T01:51:26.749604",
+     "start_time": "2023-10-27T12:41:45.839656",
      "status": "completed"
     },
     "tags": []
@@ -964,20 +964,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "37751abd",
+   "id": "3c842374",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:26.768190Z",
-     "iopub.status.busy": "2023-10-27T01:51:26.767872Z",
-     "iopub.status.idle": "2023-10-27T01:51:30.096282Z",
-     "shell.execute_reply": "2023-10-27T01:51:30.095288Z"
+     "iopub.execute_input": "2023-10-27T12:41:45.856770Z",
+     "iopub.status.busy": "2023-10-27T12:41:45.856454Z",
+     "iopub.status.idle": "2023-10-27T12:41:49.011035Z",
+     "shell.execute_reply": "2023-10-27T12:41:49.010356Z"
     },
     "id": "8JLNMCp6XUqX",
     "papermill": {
-     "duration": 3.336611,
-     "end_time": "2023-10-27T01:51:30.098030",
+     "duration": 3.162513,
+     "end_time": "2023-10-27T12:41:49.012806",
      "exception": false,
-     "start_time": "2023-10-27T01:51:26.761419",
+     "start_time": "2023-10-27T12:41:45.850293",
      "status": "completed"
     },
     "tags": []
@@ -987,7 +987,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-74d11f31-49bc-406f-91bf-87c5cc55a086\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-f41e081e-69a7-44ef-a0f4-dc47b42ba3cb\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1097,7 +1097,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-74d11f31-49bc-406f-91bf-87c5cc55a086')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-f41e081e-69a7-44ef-a0f4-dc47b42ba3cb')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1149,12 +1149,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-74d11f31-49bc-406f-91bf-87c5cc55a086 button.colab-df-convert');\n",
+       "        document.querySelector('#df-f41e081e-69a7-44ef-a0f4-dc47b42ba3cb button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-74d11f31-49bc-406f-91bf-87c5cc55a086');\n",
+       "        const element = document.querySelector('#df-f41e081e-69a7-44ef-a0f4-dc47b42ba3cb');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1226,14 +1226,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d564b03",
+   "id": "0b42552f",
    "metadata": {
     "id": "MO4Q2yGaZb-z",
     "papermill": {
-     "duration": 0.005704,
-     "end_time": "2023-10-27T01:51:30.110190",
+     "duration": 0.00614,
+     "end_time": "2023-10-27T12:41:49.024823",
      "exception": false,
-     "start_time": "2023-10-27T01:51:30.104486",
+     "start_time": "2023-10-27T12:41:49.018683",
      "status": "completed"
     },
     "tags": []
@@ -1248,14 +1248,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fb1c547",
+   "id": "7c98b7ac",
    "metadata": {
     "id": "p3Thd5reazOw",
     "papermill": {
-     "duration": 0.005301,
-     "end_time": "2023-10-27T01:51:30.121170",
+     "duration": 0.005413,
+     "end_time": "2023-10-27T12:41:49.035721",
      "exception": false,
-     "start_time": "2023-10-27T01:51:30.115869",
+     "start_time": "2023-10-27T12:41:49.030308",
      "status": "completed"
     },
     "tags": []
@@ -1271,20 +1271,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "3d37dc35",
+   "id": "9746b0f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:30.134819Z",
-     "iopub.status.busy": "2023-10-27T01:51:30.134469Z",
-     "iopub.status.idle": "2023-10-27T01:51:33.716190Z",
-     "shell.execute_reply": "2023-10-27T01:51:33.715295Z"
+     "iopub.execute_input": "2023-10-27T12:41:49.048198Z",
+     "iopub.status.busy": "2023-10-27T12:41:49.047854Z",
+     "iopub.status.idle": "2023-10-27T12:41:52.530505Z",
+     "shell.execute_reply": "2023-10-27T12:41:52.529846Z"
     },
     "id": "kg9gKhfzbcmR",
     "papermill": {
-     "duration": 3.591272,
-     "end_time": "2023-10-27T01:51:33.718140",
+     "duration": 3.491061,
+     "end_time": "2023-10-27T12:41:52.532251",
      "exception": false,
-     "start_time": "2023-10-27T01:51:30.126868",
+     "start_time": "2023-10-27T12:41:49.041190",
      "status": "completed"
     },
     "tags": []
@@ -1294,7 +1294,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-e0b30863-2548-4af8-a5e2-30c3e669b638\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-efbfd5e6-aa9e-409a-9d48-d62098f08f2a\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1339,7 +1339,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-e0b30863-2548-4af8-a5e2-30c3e669b638')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-efbfd5e6-aa9e-409a-9d48-d62098f08f2a')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1391,12 +1391,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-e0b30863-2548-4af8-a5e2-30c3e669b638 button.colab-df-convert');\n",
+       "        document.querySelector('#df-efbfd5e6-aa9e-409a-9d48-d62098f08f2a button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-e0b30863-2548-4af8-a5e2-30c3e669b638');\n",
+       "        const element = document.querySelector('#df-efbfd5e6-aa9e-409a-9d48-d62098f08f2a');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1463,14 +1463,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3f0fb97",
+   "id": "000f79ba",
    "metadata": {
     "id": "Y53cny6PcAa4",
     "papermill": {
-     "duration": 0.006144,
-     "end_time": "2023-10-27T01:51:33.730926",
+     "duration": 0.006048,
+     "end_time": "2023-10-27T12:41:52.544342",
      "exception": false,
-     "start_time": "2023-10-27T01:51:33.724782",
+     "start_time": "2023-10-27T12:41:52.538294",
      "status": "completed"
     },
     "tags": []
@@ -1496,20 +1496,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "97d66d01",
+   "id": "0585e449",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:33.744935Z",
-     "iopub.status.busy": "2023-10-27T01:51:33.744653Z",
-     "iopub.status.idle": "2023-10-27T01:51:36.883103Z",
-     "shell.execute_reply": "2023-10-27T01:51:36.882263Z"
+     "iopub.execute_input": "2023-10-27T12:41:52.556916Z",
+     "iopub.status.busy": "2023-10-27T12:41:52.556610Z",
+     "iopub.status.idle": "2023-10-27T12:41:55.791194Z",
+     "shell.execute_reply": "2023-10-27T12:41:55.790469Z"
     },
     "id": "5_Z8vRoyRcl6",
     "papermill": {
-     "duration": 3.14741,
-     "end_time": "2023-10-27T01:51:36.884867",
+     "duration": 3.243215,
+     "end_time": "2023-10-27T12:41:55.793164",
      "exception": false,
-     "start_time": "2023-10-27T01:51:33.737457",
+     "start_time": "2023-10-27T12:41:52.549949",
      "status": "completed"
     },
     "tags": []
@@ -1519,7 +1519,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-9de303a2-378c-4394-bdef-949ea8bbd1e4\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1552,7 +1552,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-9de303a2-378c-4394-bdef-949ea8bbd1e4')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1604,12 +1604,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d button.colab-df-convert');\n",
+       "        document.querySelector('#df-9de303a2-378c-4394-bdef-949ea8bbd1e4 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d');\n",
+       "        const element = document.querySelector('#df-9de303a2-378c-4394-bdef-949ea8bbd1e4');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1666,14 +1666,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61c7625a",
+   "id": "53b7154a",
    "metadata": {
     "id": "r9JsFvdR8OUv",
     "papermill": {
-     "duration": 0.005769,
-     "end_time": "2023-10-27T01:51:36.897440",
+     "duration": 0.006332,
+     "end_time": "2023-10-27T12:41:55.806065",
      "exception": false,
-     "start_time": "2023-10-27T01:51:36.891671",
+     "start_time": "2023-10-27T12:41:55.799733",
      "status": "completed"
     },
     "tags": []
@@ -1689,20 +1689,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2aa06d09",
+   "id": "8e2cd32a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:36.911076Z",
-     "iopub.status.busy": "2023-10-27T01:51:36.910778Z",
-     "iopub.status.idle": "2023-10-27T01:51:40.206649Z",
-     "shell.execute_reply": "2023-10-27T01:51:40.205782Z"
+     "iopub.execute_input": "2023-10-27T12:41:55.819447Z",
+     "iopub.status.busy": "2023-10-27T12:41:55.819116Z",
+     "iopub.status.idle": "2023-10-27T12:41:58.929162Z",
+     "shell.execute_reply": "2023-10-27T12:41:58.928491Z"
     },
     "id": "OZfB1qDgSKNU",
     "papermill": {
-     "duration": 3.305209,
-     "end_time": "2023-10-27T01:51:40.208601",
+     "duration": 3.118891,
+     "end_time": "2023-10-27T12:41:58.930869",
      "exception": false,
-     "start_time": "2023-10-27T01:51:36.903392",
+     "start_time": "2023-10-27T12:41:55.811978",
      "status": "completed"
     },
     "tags": []
@@ -1712,7 +1712,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-8e347713-5996-47b7-b1d2-05d14d9613ca\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-6c6543bd-846c-41b6-9978-471b460757bc\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1822,7 +1822,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-8e347713-5996-47b7-b1d2-05d14d9613ca')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-6c6543bd-846c-41b6-9978-471b460757bc')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1874,12 +1874,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-8e347713-5996-47b7-b1d2-05d14d9613ca button.colab-df-convert');\n",
+       "        document.querySelector('#df-6c6543bd-846c-41b6-9978-471b460757bc button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-8e347713-5996-47b7-b1d2-05d14d9613ca');\n",
+       "        const element = document.querySelector('#df-6c6543bd-846c-41b6-9978-471b460757bc');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1969,14 +1969,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5689f5a8",
+   "id": "039dbfd3",
    "metadata": {
     "id": "xogRaN9RSJnq",
     "papermill": {
-     "duration": 0.006793,
-     "end_time": "2023-10-27T01:51:40.222894",
+     "duration": 0.007001,
+     "end_time": "2023-10-27T12:41:58.944467",
      "exception": false,
-     "start_time": "2023-10-27T01:51:40.216101",
+     "start_time": "2023-10-27T12:41:58.937466",
      "status": "completed"
     },
     "tags": []
@@ -1994,20 +1994,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "17f3c5a8",
+   "id": "cc529cf1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:40.236871Z",
-     "iopub.status.busy": "2023-10-27T01:51:40.236599Z",
-     "iopub.status.idle": "2023-10-27T01:51:44.480068Z",
-     "shell.execute_reply": "2023-10-27T01:51:44.479291Z"
+     "iopub.execute_input": "2023-10-27T12:41:58.958594Z",
+     "iopub.status.busy": "2023-10-27T12:41:58.958277Z",
+     "iopub.status.idle": "2023-10-27T12:42:02.296954Z",
+     "shell.execute_reply": "2023-10-27T12:42:02.296296Z"
     },
     "id": "RAbOS0x9dfOe",
     "papermill": {
-     "duration": 4.253084,
-     "end_time": "2023-10-27T01:51:44.482166",
+     "duration": 3.347903,
+     "end_time": "2023-10-27T12:42:02.298713",
      "exception": false,
-     "start_time": "2023-10-27T01:51:40.229082",
+     "start_time": "2023-10-27T12:41:58.950810",
      "status": "completed"
     },
     "tags": []
@@ -2017,7 +2017,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-bfdef6fd-9822-41cf-bd69-c025efb50ff6\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-6062b8a3-26e2-4a69-b1d6-04abd7240459\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -2052,7 +2052,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-bfdef6fd-9822-41cf-bd69-c025efb50ff6')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-6062b8a3-26e2-4a69-b1d6-04abd7240459')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -2104,12 +2104,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-bfdef6fd-9822-41cf-bd69-c025efb50ff6 button.colab-df-convert');\n",
+       "        document.querySelector('#df-6062b8a3-26e2-4a69-b1d6-04abd7240459 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-bfdef6fd-9822-41cf-bd69-c025efb50ff6');\n",
+       "        const element = document.querySelector('#df-6062b8a3-26e2-4a69-b1d6-04abd7240459');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -2172,14 +2172,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2d84f5d",
+   "id": "a9f5acba",
    "metadata": {
     "id": "ab2lCsz5dyxA",
     "papermill": {
-     "duration": 0.006469,
-     "end_time": "2023-10-27T01:51:44.495680",
+     "duration": 0.010244,
+     "end_time": "2023-10-27T12:42:02.316722",
      "exception": false,
-     "start_time": "2023-10-27T01:51:44.489211",
+     "start_time": "2023-10-27T12:42:02.306478",
      "status": "completed"
     },
     "tags": []
@@ -2190,14 +2190,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ae90c8f",
+   "id": "f1e0f9b8",
    "metadata": {
     "id": "6yE502BaecuL",
     "papermill": {
-     "duration": 0.006215,
-     "end_time": "2023-10-27T01:51:44.508251",
+     "duration": 0.006422,
+     "end_time": "2023-10-27T12:42:02.329638",
      "exception": false,
-     "start_time": "2023-10-27T01:51:44.502036",
+     "start_time": "2023-10-27T12:42:02.323216",
      "status": "completed"
     },
     "tags": []
@@ -2213,20 +2213,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "cf9d3147",
+   "id": "c12894b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:44.522557Z",
-     "iopub.status.busy": "2023-10-27T01:51:44.522268Z",
-     "iopub.status.idle": "2023-10-27T01:51:47.532248Z",
-     "shell.execute_reply": "2023-10-27T01:51:47.531271Z"
+     "iopub.execute_input": "2023-10-27T12:42:02.344288Z",
+     "iopub.status.busy": "2023-10-27T12:42:02.343946Z",
+     "iopub.status.idle": "2023-10-27T12:42:06.030938Z",
+     "shell.execute_reply": "2023-10-27T12:42:06.030241Z"
     },
     "id": "Dc_6GR1DfiZc",
     "papermill": {
-     "duration": 3.019631,
-     "end_time": "2023-10-27T01:51:47.534391",
+     "duration": 3.696472,
+     "end_time": "2023-10-27T12:42:06.032680",
      "exception": false,
-     "start_time": "2023-10-27T01:51:44.514760",
+     "start_time": "2023-10-27T12:42:02.336208",
      "status": "completed"
     },
     "tags": []
@@ -2236,7 +2236,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-3ebe4d92-58c2-4968-ac09-4a6827bc143b\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-8c38244d-8175-4238-98a7-dfb5ca1909a7\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -2273,7 +2273,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-3ebe4d92-58c2-4968-ac09-4a6827bc143b')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-8c38244d-8175-4238-98a7-dfb5ca1909a7')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -2325,12 +2325,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-3ebe4d92-58c2-4968-ac09-4a6827bc143b button.colab-df-convert');\n",
+       "        document.querySelector('#df-8c38244d-8175-4238-98a7-dfb5ca1909a7 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-3ebe4d92-58c2-4968-ac09-4a6827bc143b');\n",
+       "        const element = document.querySelector('#df-8c38244d-8175-4238-98a7-dfb5ca1909a7');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -2407,14 +2407,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6122ceef",
+   "id": "4fba1ece",
    "metadata": {
     "id": "5cbTYu-4hxH_",
     "papermill": {
-     "duration": 0.007663,
-     "end_time": "2023-10-27T01:51:47.549536",
+     "duration": 0.007072,
+     "end_time": "2023-10-27T12:42:06.047815",
      "exception": false,
-     "start_time": "2023-10-27T01:51:47.541873",
+     "start_time": "2023-10-27T12:42:06.040743",
      "status": "completed"
     },
     "tags": []
@@ -2429,14 +2429,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ec1d61e",
+   "id": "adbd610d",
    "metadata": {
     "id": "pe1q7WLekEAS",
     "papermill": {
-     "duration": 0.00699,
-     "end_time": "2023-10-27T01:51:47.563540",
+     "duration": 0.007042,
+     "end_time": "2023-10-27T12:42:06.062075",
      "exception": false,
-     "start_time": "2023-10-27T01:51:47.556550",
+     "start_time": "2023-10-27T12:42:06.055033",
      "status": "completed"
     },
     "tags": []
@@ -2456,14 +2456,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70944d8e",
+   "id": "8e2036c7",
    "metadata": {
     "id": "wd0NQt62SkC8",
     "papermill": {
-     "duration": 0.00687,
-     "end_time": "2023-10-27T01:51:47.577037",
+     "duration": 0.006782,
+     "end_time": "2023-10-27T12:42:06.075720",
      "exception": false,
-     "start_time": "2023-10-27T01:51:47.570167",
+     "start_time": "2023-10-27T12:42:06.068938",
      "status": "completed"
     },
     "tags": []
@@ -2481,20 +2481,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "72f0e19c",
+   "id": "9fd70385",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:51:47.591791Z",
-     "iopub.status.busy": "2023-10-27T01:51:47.591516Z",
-     "iopub.status.idle": "2023-10-27T01:51:51.307029Z",
-     "shell.execute_reply": "2023-10-27T01:51:51.306143Z"
+     "iopub.execute_input": "2023-10-27T12:42:06.091267Z",
+     "iopub.status.busy": "2023-10-27T12:42:06.090929Z",
+     "iopub.status.idle": "2023-10-27T12:42:09.387493Z",
+     "shell.execute_reply": "2023-10-27T12:42:09.386461Z"
     },
     "id": "grIq1xKjpkEC",
     "papermill": {
-     "duration": 3.725411,
-     "end_time": "2023-10-27T01:51:51.308998",
+     "duration": 3.306663,
+     "end_time": "2023-10-27T12:42:09.389248",
      "exception": false,
-     "start_time": "2023-10-27T01:51:47.583587",
+     "start_time": "2023-10-27T12:42:06.082585",
      "status": "completed"
     },
     "tags": []
@@ -2504,7 +2504,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-5cc07103-1e00-415b-ab64-7706090090d2\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-836bff24-0ca6-4ce4-8b98-93cb1b49a3c9\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -2590,7 +2590,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-5cc07103-1e00-415b-ab64-7706090090d2')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-836bff24-0ca6-4ce4-8b98-93cb1b49a3c9')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -2642,12 +2642,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-5cc07103-1e00-415b-ab64-7706090090d2 button.colab-df-convert');\n",
+       "        document.querySelector('#df-836bff24-0ca6-4ce4-8b98-93cb1b49a3c9 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-5cc07103-1e00-415b-ab64-7706090090d2');\n",
+       "        const element = document.querySelector('#df-836bff24-0ca6-4ce4-8b98-93cb1b49a3c9');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -2754,14 +2754,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "524ed80f",
+   "id": "e93a8e96",
    "metadata": {
     "id": "WZKDEsriZiyu",
     "papermill": {
-     "duration": 0.007915,
-     "end_time": "2023-10-27T01:51:51.325610",
+     "duration": 0.00726,
+     "end_time": "2023-10-27T12:42:09.404295",
      "exception": false,
-     "start_time": "2023-10-27T01:51:51.317695",
+     "start_time": "2023-10-27T12:42:09.397035",
      "status": "completed"
     },
     "tags": []
@@ -2774,14 +2774,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc31a345",
+   "id": "8291a916",
    "metadata": {
     "id": "It9Md7yzwTn4",
     "papermill": {
-     "duration": 0.008002,
-     "end_time": "2023-10-27T01:51:51.341171",
+     "duration": 0.006912,
+     "end_time": "2023-10-27T12:42:09.418233",
      "exception": false,
-     "start_time": "2023-10-27T01:51:51.333169",
+     "start_time": "2023-10-27T12:42:09.411321",
      "status": "completed"
     },
     "tags": []
@@ -2822,14 +2822,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.670011,
-   "end_time": "2023-10-27T01:51:51.858885",
+   "duration": 32.539644,
+   "end_time": "2023-10-27T12:42:09.932134",
    "environment_variables": {},
    "exception": null,
    "input_path": "/content/notebooks/getting_started/part2_searching_basics.ipynb",
    "output_path": "/content/test/outputs/part2_searching_basics_papermill_output.ipynb",
    "parameters": {},
-   "start_time": "2023-10-27T01:51:18.188874",
+   "start_time": "2023-10-27T12:41:37.392490",
    "version": "2.4.0"
   }
  },

--- a/test/outputs/part2_searching_basics_papermill_output.ipynb
+++ b/test/outputs/part2_searching_basics_papermill_output.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8ce1ba17",
+   "id": "cc51795b",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github",
     "papermill": {
-     "duration": 0.007341,
-     "end_time": "2023-10-26T14:57:31.946590",
+     "duration": 0.00588,
+     "end_time": "2023-10-27T01:51:19.607628",
      "exception": false,
-     "start_time": "2023-10-26T14:57:31.939249",
+     "start_time": "2023-10-27T01:51:19.601748",
      "status": "completed"
     },
     "tags": []
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca576dfc",
+   "id": "9ffc54c8",
    "metadata": {
     "id": "KmXfYFZtja2F",
     "papermill": {
-     "duration": 0.005693,
-     "end_time": "2023-10-26T14:57:31.958132",
+     "duration": 0.004624,
+     "end_time": "2023-10-27T01:51:19.617373",
      "exception": false,
-     "start_time": "2023-10-26T14:57:31.952439",
+     "start_time": "2023-10-27T01:51:19.612749",
      "status": "completed"
     },
     "tags": []
@@ -55,14 +55,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "414ea69a",
+   "id": "ba0d801d",
    "metadata": {
     "id": "-z3XVLAgArvo",
     "papermill": {
-     "duration": 0.005191,
-     "end_time": "2023-10-26T14:57:31.968579",
+     "duration": 0.004362,
+     "end_time": "2023-10-27T01:51:19.626572",
      "exception": false,
-     "start_time": "2023-10-26T14:57:31.963388",
+     "start_time": "2023-10-27T01:51:19.622210",
      "status": "completed"
     },
     "tags": []
@@ -75,14 +75,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2a1cfe2",
+   "id": "f77ee299",
    "metadata": {
     "id": "a4Q-kRDW77Iy",
     "papermill": {
-     "duration": 0.005152,
-     "end_time": "2023-10-26T14:57:31.979037",
+     "duration": 0.004646,
+     "end_time": "2023-10-27T01:51:19.635779",
      "exception": false,
-     "start_time": "2023-10-26T14:57:31.973885",
+     "start_time": "2023-10-27T01:51:19.631133",
      "status": "completed"
     },
     "tags": []
@@ -100,21 +100,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "38771c00",
+   "id": "6a03bc4f",
    "metadata": {
     "cellView": "form",
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:31.992331Z",
-     "iopub.status.busy": "2023-10-26T14:57:31.991967Z",
-     "iopub.status.idle": "2023-10-26T14:57:31.997874Z",
-     "shell.execute_reply": "2023-10-26T14:57:31.997067Z"
+     "iopub.execute_input": "2023-10-27T01:51:19.647680Z",
+     "iopub.status.busy": "2023-10-27T01:51:19.647331Z",
+     "iopub.status.idle": "2023-10-27T01:51:19.651416Z",
+     "shell.execute_reply": "2023-10-27T01:51:19.650717Z"
     },
     "id": "bDGChJBK9ooq",
     "papermill": {
-     "duration": 0.015746,
-     "end_time": "2023-10-26T14:57:32.000038",
+     "duration": 0.012785,
+     "end_time": "2023-10-27T01:51:19.653065",
      "exception": false,
-     "start_time": "2023-10-26T14:57:31.984292",
+     "start_time": "2023-10-27T01:51:19.640280",
      "status": "completed"
     },
     "tags": []
@@ -136,14 +136,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30e7efb9",
+   "id": "2d11bbe5",
    "metadata": {
     "id": "zrbT7voq7yU5",
     "papermill": {
-     "duration": 0.006953,
-     "end_time": "2023-10-26T14:57:32.013133",
+     "duration": 0.004801,
+     "end_time": "2023-10-27T01:51:19.662488",
      "exception": false,
-     "start_time": "2023-10-26T14:57:32.006180",
+     "start_time": "2023-10-27T01:51:19.657687",
      "status": "completed"
     },
     "tags": []
@@ -158,14 +158,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ffbc536",
+   "id": "276dda5e",
    "metadata": {
     "id": "kZMMjky1898-",
     "papermill": {
-     "duration": 0.005762,
-     "end_time": "2023-10-26T14:57:32.025044",
+     "duration": 0.004636,
+     "end_time": "2023-10-27T01:51:19.671948",
      "exception": false,
-     "start_time": "2023-10-26T14:57:32.019282",
+     "start_time": "2023-10-27T01:51:19.667312",
      "status": "completed"
     },
     "tags": []
@@ -194,14 +194,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f06b4a5c",
+   "id": "08d0effd",
    "metadata": {
     "id": "pYEiJZYy_oZW",
     "papermill": {
-     "duration": 0.00557,
-     "end_time": "2023-10-26T14:57:32.038364",
+     "duration": 0.004537,
+     "end_time": "2023-10-27T01:51:19.681203",
      "exception": false,
-     "start_time": "2023-10-26T14:57:32.032794",
+     "start_time": "2023-10-27T01:51:19.676666",
      "status": "completed"
     },
     "tags": []
@@ -234,14 +234,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da2aac58",
+   "id": "b69b20af",
    "metadata": {
     "id": "Qke1owafZiyp",
     "papermill": {
-     "duration": 0.005901,
-     "end_time": "2023-10-26T14:57:32.049725",
+     "duration": 0.005249,
+     "end_time": "2023-10-27T01:51:19.691519",
      "exception": false,
-     "start_time": "2023-10-26T14:57:32.043824",
+     "start_time": "2023-10-27T01:51:19.686270",
      "status": "completed"
     },
     "tags": []
@@ -268,14 +268,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "321289b6",
+   "id": "397d1ca1",
    "metadata": {
     "id": "9gE4aq0NLizR",
     "papermill": {
-     "duration": 0.005781,
-     "end_time": "2023-10-26T14:57:32.061287",
+     "duration": 0.004657,
+     "end_time": "2023-10-27T01:51:19.700956",
      "exception": false,
-     "start_time": "2023-10-26T14:57:32.055506",
+     "start_time": "2023-10-27T01:51:19.696299",
      "status": "completed"
     },
     "tags": []
@@ -293,20 +293,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "241e185f",
+   "id": "ab81f4e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:32.079749Z",
-     "iopub.status.busy": "2023-10-26T14:57:32.079396Z",
-     "iopub.status.idle": "2023-10-26T14:57:36.350673Z",
-     "shell.execute_reply": "2023-10-26T14:57:36.349762Z"
+     "iopub.execute_input": "2023-10-27T01:51:19.712204Z",
+     "iopub.status.busy": "2023-10-27T01:51:19.711753Z",
+     "iopub.status.idle": "2023-10-27T01:51:23.514448Z",
+     "shell.execute_reply": "2023-10-27T01:51:23.513473Z"
     },
     "id": "hfoS7obINKO7",
     "papermill": {
-     "duration": 4.286848,
-     "end_time": "2023-10-26T14:57:36.353673",
+     "duration": 3.810373,
+     "end_time": "2023-10-27T01:51:23.516128",
      "exception": false,
-     "start_time": "2023-10-26T14:57:32.066825",
+     "start_time": "2023-10-27T01:51:19.705755",
      "status": "completed"
     },
     "tags": []
@@ -316,7 +316,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-6fc6623d-bd83-42ac-bdf1-e8acde4bac1e\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -390,7 +390,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-6fc6623d-bd83-42ac-bdf1-e8acde4bac1e')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -442,12 +442,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-6fc6623d-bd83-42ac-bdf1-e8acde4bac1e button.colab-df-convert');\n",
+       "        document.querySelector('#df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-6fc6623d-bd83-42ac-bdf1-e8acde4bac1e');\n",
+       "        const element = document.querySelector('#df-dbfc4a2a-e9dc-4787-8e94-e0811bdd8c19');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -514,14 +514,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cdc8bcd",
+   "id": "ccc4b88d",
    "metadata": {
     "id": "7ofFg6oaNpHw",
     "papermill": {
-     "duration": 0.007874,
-     "end_time": "2023-10-26T14:57:36.369057",
+     "duration": 0.00523,
+     "end_time": "2023-10-27T01:51:23.527192",
      "exception": false,
-     "start_time": "2023-10-26T14:57:36.361183",
+     "start_time": "2023-10-27T01:51:23.521962",
      "status": "completed"
     },
     "tags": []
@@ -541,14 +541,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a04b28cc",
+   "id": "4941c4f8",
    "metadata": {
     "id": "3kkHUgqaP2tl",
     "papermill": {
-     "duration": 0.006459,
-     "end_time": "2023-10-26T14:57:36.382312",
+     "duration": 0.005058,
+     "end_time": "2023-10-27T01:51:23.537588",
      "exception": false,
-     "start_time": "2023-10-26T14:57:36.375853",
+     "start_time": "2023-10-27T01:51:23.532530",
      "status": "completed"
     },
     "tags": []
@@ -564,20 +564,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5b28af01",
+   "id": "b909d018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:36.396734Z",
-     "iopub.status.busy": "2023-10-26T14:57:36.396219Z",
-     "iopub.status.idle": "2023-10-26T14:57:39.911380Z",
-     "shell.execute_reply": "2023-10-26T14:57:39.910466Z"
+     "iopub.execute_input": "2023-10-27T01:51:23.549813Z",
+     "iopub.status.busy": "2023-10-27T01:51:23.549434Z",
+     "iopub.status.idle": "2023-10-27T01:51:26.741795Z",
+     "shell.execute_reply": "2023-10-27T01:51:26.740943Z"
     },
     "id": "5w9956q-P1YS",
     "papermill": {
-     "duration": 3.524337,
-     "end_time": "2023-10-26T14:57:39.913463",
+     "duration": 3.200498,
+     "end_time": "2023-10-27T01:51:26.743558",
      "exception": false,
-     "start_time": "2023-10-26T14:57:36.389126",
+     "start_time": "2023-10-27T01:51:23.543060",
      "status": "completed"
     },
     "tags": []
@@ -587,7 +587,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-5600fd0a-e45f-4996-81df-6c903603a400\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-d06754fa-db0b-427e-9b53-8ebd86115896\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -788,7 +788,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-5600fd0a-e45f-4996-81df-6c903603a400')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-d06754fa-db0b-427e-9b53-8ebd86115896')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -840,12 +840,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-5600fd0a-e45f-4996-81df-6c903603a400 button.colab-df-convert');\n",
+       "        document.querySelector('#df-d06754fa-db0b-427e-9b53-8ebd86115896 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-5600fd0a-e45f-4996-81df-6c903603a400');\n",
+       "        const element = document.querySelector('#df-d06754fa-db0b-427e-9b53-8ebd86115896');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -941,14 +941,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f1a6f9b",
+   "id": "0c877afb",
    "metadata": {
     "id": "h9kC-9AAQkun",
     "papermill": {
-     "duration": 0.007054,
-     "end_time": "2023-10-26T14:57:39.928016",
+     "duration": 0.006174,
+     "end_time": "2023-10-27T01:51:26.755778",
      "exception": false,
-     "start_time": "2023-10-26T14:57:39.920962",
+     "start_time": "2023-10-27T01:51:26.749604",
      "status": "completed"
     },
     "tags": []
@@ -964,20 +964,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "29a0d5d8",
+   "id": "37751abd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:39.946743Z",
-     "iopub.status.busy": "2023-10-26T14:57:39.946292Z",
-     "iopub.status.idle": "2023-10-26T14:57:43.196995Z",
-     "shell.execute_reply": "2023-10-26T14:57:43.196141Z"
+     "iopub.execute_input": "2023-10-27T01:51:26.768190Z",
+     "iopub.status.busy": "2023-10-27T01:51:26.767872Z",
+     "iopub.status.idle": "2023-10-27T01:51:30.096282Z",
+     "shell.execute_reply": "2023-10-27T01:51:30.095288Z"
     },
     "id": "8JLNMCp6XUqX",
     "papermill": {
-     "duration": 3.265586,
-     "end_time": "2023-10-26T14:57:43.200451",
+     "duration": 3.336611,
+     "end_time": "2023-10-27T01:51:30.098030",
      "exception": false,
-     "start_time": "2023-10-26T14:57:39.934865",
+     "start_time": "2023-10-27T01:51:26.761419",
      "status": "completed"
     },
     "tags": []
@@ -987,7 +987,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-39bdd1c6-3fcd-4783-807c-dc9515d7b05f\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-74d11f31-49bc-406f-91bf-87c5cc55a086\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1097,7 +1097,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-39bdd1c6-3fcd-4783-807c-dc9515d7b05f')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-74d11f31-49bc-406f-91bf-87c5cc55a086')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1149,12 +1149,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-39bdd1c6-3fcd-4783-807c-dc9515d7b05f button.colab-df-convert');\n",
+       "        document.querySelector('#df-74d11f31-49bc-406f-91bf-87c5cc55a086 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-39bdd1c6-3fcd-4783-807c-dc9515d7b05f');\n",
+       "        const element = document.querySelector('#df-74d11f31-49bc-406f-91bf-87c5cc55a086');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1226,14 +1226,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf6a1ade",
+   "id": "9d564b03",
    "metadata": {
     "id": "MO4Q2yGaZb-z",
     "papermill": {
-     "duration": 0.00775,
-     "end_time": "2023-10-26T14:57:43.215458",
+     "duration": 0.005704,
+     "end_time": "2023-10-27T01:51:30.110190",
      "exception": false,
-     "start_time": "2023-10-26T14:57:43.207708",
+     "start_time": "2023-10-27T01:51:30.104486",
      "status": "completed"
     },
     "tags": []
@@ -1248,14 +1248,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7818f2f0",
+   "id": "5fb1c547",
    "metadata": {
     "id": "p3Thd5reazOw",
     "papermill": {
-     "duration": 0.007443,
-     "end_time": "2023-10-26T14:57:43.230426",
+     "duration": 0.005301,
+     "end_time": "2023-10-27T01:51:30.121170",
      "exception": false,
-     "start_time": "2023-10-26T14:57:43.222983",
+     "start_time": "2023-10-27T01:51:30.115869",
      "status": "completed"
     },
     "tags": []
@@ -1271,20 +1271,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "bfc84601",
+   "id": "3d37dc35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:43.247428Z",
-     "iopub.status.busy": "2023-10-26T14:57:43.247082Z",
-     "iopub.status.idle": "2023-10-26T14:57:46.722708Z",
-     "shell.execute_reply": "2023-10-26T14:57:46.721514Z"
+     "iopub.execute_input": "2023-10-27T01:51:30.134819Z",
+     "iopub.status.busy": "2023-10-27T01:51:30.134469Z",
+     "iopub.status.idle": "2023-10-27T01:51:33.716190Z",
+     "shell.execute_reply": "2023-10-27T01:51:33.715295Z"
     },
     "id": "kg9gKhfzbcmR",
     "papermill": {
-     "duration": 3.487794,
-     "end_time": "2023-10-26T14:57:46.725509",
+     "duration": 3.591272,
+     "end_time": "2023-10-27T01:51:33.718140",
      "exception": false,
-     "start_time": "2023-10-26T14:57:43.237715",
+     "start_time": "2023-10-27T01:51:30.126868",
      "status": "completed"
     },
     "tags": []
@@ -1294,7 +1294,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-4d239c13-735b-44f2-a633-16799eecf1c7\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-e0b30863-2548-4af8-a5e2-30c3e669b638\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1339,7 +1339,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-4d239c13-735b-44f2-a633-16799eecf1c7')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-e0b30863-2548-4af8-a5e2-30c3e669b638')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1391,12 +1391,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-4d239c13-735b-44f2-a633-16799eecf1c7 button.colab-df-convert');\n",
+       "        document.querySelector('#df-e0b30863-2548-4af8-a5e2-30c3e669b638 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-4d239c13-735b-44f2-a633-16799eecf1c7');\n",
+       "        const element = document.querySelector('#df-e0b30863-2548-4af8-a5e2-30c3e669b638');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1463,14 +1463,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc91f825",
+   "id": "c3f0fb97",
    "metadata": {
     "id": "Y53cny6PcAa4",
     "papermill": {
-     "duration": 0.009445,
-     "end_time": "2023-10-26T14:57:46.744002",
+     "duration": 0.006144,
+     "end_time": "2023-10-27T01:51:33.730926",
      "exception": false,
-     "start_time": "2023-10-26T14:57:46.734557",
+     "start_time": "2023-10-27T01:51:33.724782",
      "status": "completed"
     },
     "tags": []
@@ -1496,20 +1496,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "f594b1e8",
+   "id": "97d66d01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:46.762764Z",
-     "iopub.status.busy": "2023-10-26T14:57:46.762274Z",
-     "iopub.status.idle": "2023-10-26T14:57:49.971455Z",
-     "shell.execute_reply": "2023-10-26T14:57:49.970634Z"
+     "iopub.execute_input": "2023-10-27T01:51:33.744935Z",
+     "iopub.status.busy": "2023-10-27T01:51:33.744653Z",
+     "iopub.status.idle": "2023-10-27T01:51:36.883103Z",
+     "shell.execute_reply": "2023-10-27T01:51:36.882263Z"
     },
     "id": "5_Z8vRoyRcl6",
     "papermill": {
-     "duration": 3.220409,
-     "end_time": "2023-10-26T14:57:49.973360",
+     "duration": 3.14741,
+     "end_time": "2023-10-27T01:51:36.884867",
      "exception": false,
-     "start_time": "2023-10-26T14:57:46.752951",
+     "start_time": "2023-10-27T01:51:33.737457",
      "status": "completed"
     },
     "tags": []
@@ -1519,7 +1519,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-ddb86424-3fb4-45c3-8e39-ad4c8db6cb70\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1552,7 +1552,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ddb86424-3fb4-45c3-8e39-ad4c8db6cb70')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1604,12 +1604,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-ddb86424-3fb4-45c3-8e39-ad4c8db6cb70 button.colab-df-convert');\n",
+       "        document.querySelector('#df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-ddb86424-3fb4-45c3-8e39-ad4c8db6cb70');\n",
+       "        const element = document.querySelector('#df-b18bf2d1-0e2b-467c-9d94-988aebbbd14d');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1666,14 +1666,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3066771e",
+   "id": "61c7625a",
    "metadata": {
     "id": "r9JsFvdR8OUv",
     "papermill": {
-     "duration": 0.007342,
-     "end_time": "2023-10-26T14:57:49.988142",
+     "duration": 0.005769,
+     "end_time": "2023-10-27T01:51:36.897440",
      "exception": false,
-     "start_time": "2023-10-26T14:57:49.980800",
+     "start_time": "2023-10-27T01:51:36.891671",
      "status": "completed"
     },
     "tags": []
@@ -1689,20 +1689,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cd658521",
+   "id": "2aa06d09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:50.003638Z",
-     "iopub.status.busy": "2023-10-26T14:57:50.003301Z",
-     "iopub.status.idle": "2023-10-26T14:57:53.139552Z",
-     "shell.execute_reply": "2023-10-26T14:57:53.138687Z"
+     "iopub.execute_input": "2023-10-27T01:51:36.911076Z",
+     "iopub.status.busy": "2023-10-27T01:51:36.910778Z",
+     "iopub.status.idle": "2023-10-27T01:51:40.206649Z",
+     "shell.execute_reply": "2023-10-27T01:51:40.205782Z"
     },
     "id": "OZfB1qDgSKNU",
     "papermill": {
-     "duration": 3.147088,
-     "end_time": "2023-10-26T14:57:53.142161",
+     "duration": 3.305209,
+     "end_time": "2023-10-27T01:51:40.208601",
      "exception": false,
-     "start_time": "2023-10-26T14:57:49.995073",
+     "start_time": "2023-10-27T01:51:36.903392",
      "status": "completed"
     },
     "tags": []
@@ -1712,7 +1712,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-33d53ff9-9959-4e83-84e2-4bd005b3bfa8\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-8e347713-5996-47b7-b1d2-05d14d9613ca\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1822,7 +1822,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-33d53ff9-9959-4e83-84e2-4bd005b3bfa8')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-8e347713-5996-47b7-b1d2-05d14d9613ca')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1874,12 +1874,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-33d53ff9-9959-4e83-84e2-4bd005b3bfa8 button.colab-df-convert');\n",
+       "        document.querySelector('#df-8e347713-5996-47b7-b1d2-05d14d9613ca button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-33d53ff9-9959-4e83-84e2-4bd005b3bfa8');\n",
+       "        const element = document.querySelector('#df-8e347713-5996-47b7-b1d2-05d14d9613ca');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1969,14 +1969,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23319bac",
+   "id": "5689f5a8",
    "metadata": {
     "id": "xogRaN9RSJnq",
     "papermill": {
-     "duration": 0.012147,
-     "end_time": "2023-10-26T14:57:53.163522",
+     "duration": 0.006793,
+     "end_time": "2023-10-27T01:51:40.222894",
      "exception": false,
-     "start_time": "2023-10-26T14:57:53.151375",
+     "start_time": "2023-10-27T01:51:40.216101",
      "status": "completed"
     },
     "tags": []
@@ -1994,20 +1994,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "464068a9",
+   "id": "17f3c5a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:53.181581Z",
-     "iopub.status.busy": "2023-10-26T14:57:53.181100Z",
-     "iopub.status.idle": "2023-10-26T14:57:56.427662Z",
-     "shell.execute_reply": "2023-10-26T14:57:56.426750Z"
+     "iopub.execute_input": "2023-10-27T01:51:40.236871Z",
+     "iopub.status.busy": "2023-10-27T01:51:40.236599Z",
+     "iopub.status.idle": "2023-10-27T01:51:44.480068Z",
+     "shell.execute_reply": "2023-10-27T01:51:44.479291Z"
     },
     "id": "RAbOS0x9dfOe",
     "papermill": {
-     "duration": 3.258211,
-     "end_time": "2023-10-26T14:57:56.430178",
+     "duration": 4.253084,
+     "end_time": "2023-10-27T01:51:44.482166",
      "exception": false,
-     "start_time": "2023-10-26T14:57:53.171967",
+     "start_time": "2023-10-27T01:51:40.229082",
      "status": "completed"
     },
     "tags": []
@@ -2017,7 +2017,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-ece857ad-e0db-4c13-b222-024999a39f16\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-bfdef6fd-9822-41cf-bd69-c025efb50ff6\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -2052,7 +2052,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ece857ad-e0db-4c13-b222-024999a39f16')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-bfdef6fd-9822-41cf-bd69-c025efb50ff6')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -2104,12 +2104,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-ece857ad-e0db-4c13-b222-024999a39f16 button.colab-df-convert');\n",
+       "        document.querySelector('#df-bfdef6fd-9822-41cf-bd69-c025efb50ff6 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-ece857ad-e0db-4c13-b222-024999a39f16');\n",
+       "        const element = document.querySelector('#df-bfdef6fd-9822-41cf-bd69-c025efb50ff6');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -2172,14 +2172,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8ad8756",
+   "id": "e2d84f5d",
    "metadata": {
     "id": "ab2lCsz5dyxA",
     "papermill": {
-     "duration": 0.008831,
-     "end_time": "2023-10-26T14:57:56.447749",
+     "duration": 0.006469,
+     "end_time": "2023-10-27T01:51:44.495680",
      "exception": false,
-     "start_time": "2023-10-26T14:57:56.438918",
+     "start_time": "2023-10-27T01:51:44.489211",
      "status": "completed"
     },
     "tags": []
@@ -2190,14 +2190,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98dde1d0",
+   "id": "7ae90c8f",
    "metadata": {
     "id": "6yE502BaecuL",
     "papermill": {
-     "duration": 0.008025,
-     "end_time": "2023-10-26T14:57:56.463703",
+     "duration": 0.006215,
+     "end_time": "2023-10-27T01:51:44.508251",
      "exception": false,
-     "start_time": "2023-10-26T14:57:56.455678",
+     "start_time": "2023-10-27T01:51:44.502036",
      "status": "completed"
     },
     "tags": []
@@ -2213,20 +2213,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "2897f317",
+   "id": "cf9d3147",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:56.482634Z",
-     "iopub.status.busy": "2023-10-26T14:57:56.482264Z",
-     "iopub.status.idle": "2023-10-26T14:57:59.910695Z",
-     "shell.execute_reply": "2023-10-26T14:57:59.909784Z"
+     "iopub.execute_input": "2023-10-27T01:51:44.522557Z",
+     "iopub.status.busy": "2023-10-27T01:51:44.522268Z",
+     "iopub.status.idle": "2023-10-27T01:51:47.532248Z",
+     "shell.execute_reply": "2023-10-27T01:51:47.531271Z"
     },
     "id": "Dc_6GR1DfiZc",
     "papermill": {
-     "duration": 3.441097,
-     "end_time": "2023-10-26T14:57:59.912863",
+     "duration": 3.019631,
+     "end_time": "2023-10-27T01:51:47.534391",
      "exception": false,
-     "start_time": "2023-10-26T14:57:56.471766",
+     "start_time": "2023-10-27T01:51:44.514760",
      "status": "completed"
     },
     "tags": []
@@ -2236,7 +2236,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-72bf94ec-62ee-48e9-897c-12137ac1f9ac\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-3ebe4d92-58c2-4968-ac09-4a6827bc143b\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -2273,7 +2273,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-72bf94ec-62ee-48e9-897c-12137ac1f9ac')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-3ebe4d92-58c2-4968-ac09-4a6827bc143b')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -2325,12 +2325,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-72bf94ec-62ee-48e9-897c-12137ac1f9ac button.colab-df-convert');\n",
+       "        document.querySelector('#df-3ebe4d92-58c2-4968-ac09-4a6827bc143b button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-72bf94ec-62ee-48e9-897c-12137ac1f9ac');\n",
+       "        const element = document.querySelector('#df-3ebe4d92-58c2-4968-ac09-4a6827bc143b');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -2407,14 +2407,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c6b0bfe",
+   "id": "6122ceef",
    "metadata": {
     "id": "5cbTYu-4hxH_",
     "papermill": {
-     "duration": 0.009218,
-     "end_time": "2023-10-26T14:57:59.931664",
+     "duration": 0.007663,
+     "end_time": "2023-10-27T01:51:47.549536",
      "exception": false,
-     "start_time": "2023-10-26T14:57:59.922446",
+     "start_time": "2023-10-27T01:51:47.541873",
      "status": "completed"
     },
     "tags": []
@@ -2429,14 +2429,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d0ac611",
+   "id": "0ec1d61e",
    "metadata": {
     "id": "pe1q7WLekEAS",
     "papermill": {
-     "duration": 0.008727,
-     "end_time": "2023-10-26T14:57:59.949196",
+     "duration": 0.00699,
+     "end_time": "2023-10-27T01:51:47.563540",
      "exception": false,
-     "start_time": "2023-10-26T14:57:59.940469",
+     "start_time": "2023-10-27T01:51:47.556550",
      "status": "completed"
     },
     "tags": []
@@ -2456,14 +2456,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb813152",
+   "id": "70944d8e",
    "metadata": {
     "id": "wd0NQt62SkC8",
     "papermill": {
-     "duration": 0.008683,
-     "end_time": "2023-10-26T14:57:59.966696",
+     "duration": 0.00687,
+     "end_time": "2023-10-27T01:51:47.577037",
      "exception": false,
-     "start_time": "2023-10-26T14:57:59.958013",
+     "start_time": "2023-10-27T01:51:47.570167",
      "status": "completed"
     },
     "tags": []
@@ -2481,20 +2481,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a457d826",
+   "id": "72f0e19c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:57:59.986005Z",
-     "iopub.status.busy": "2023-10-26T14:57:59.985587Z",
-     "iopub.status.idle": "2023-10-26T14:58:02.858962Z",
-     "shell.execute_reply": "2023-10-26T14:58:02.858139Z"
+     "iopub.execute_input": "2023-10-27T01:51:47.591791Z",
+     "iopub.status.busy": "2023-10-27T01:51:47.591516Z",
+     "iopub.status.idle": "2023-10-27T01:51:51.307029Z",
+     "shell.execute_reply": "2023-10-27T01:51:51.306143Z"
     },
     "id": "grIq1xKjpkEC",
     "papermill": {
-     "duration": 2.885677,
-     "end_time": "2023-10-26T14:58:02.861016",
+     "duration": 3.725411,
+     "end_time": "2023-10-27T01:51:51.308998",
      "exception": false,
-     "start_time": "2023-10-26T14:57:59.975339",
+     "start_time": "2023-10-27T01:51:47.583587",
      "status": "completed"
     },
     "tags": []
@@ -2504,7 +2504,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-d3668bd2-2380-4372-b2f8-141393d33991\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-5cc07103-1e00-415b-ab64-7706090090d2\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -2590,7 +2590,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-d3668bd2-2380-4372-b2f8-141393d33991')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-5cc07103-1e00-415b-ab64-7706090090d2')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -2642,12 +2642,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-d3668bd2-2380-4372-b2f8-141393d33991 button.colab-df-convert');\n",
+       "        document.querySelector('#df-5cc07103-1e00-415b-ab64-7706090090d2 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-d3668bd2-2380-4372-b2f8-141393d33991');\n",
+       "        const element = document.querySelector('#df-5cc07103-1e00-415b-ab64-7706090090d2');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -2754,14 +2754,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec029674",
+   "id": "524ed80f",
    "metadata": {
     "id": "WZKDEsriZiyu",
     "papermill": {
-     "duration": 0.010206,
-     "end_time": "2023-10-26T14:58:02.880915",
+     "duration": 0.007915,
+     "end_time": "2023-10-27T01:51:51.325610",
      "exception": false,
-     "start_time": "2023-10-26T14:58:02.870709",
+     "start_time": "2023-10-27T01:51:51.317695",
      "status": "completed"
     },
     "tags": []
@@ -2774,14 +2774,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c5a1a65",
+   "id": "cc31a345",
    "metadata": {
     "id": "It9Md7yzwTn4",
     "papermill": {
-     "duration": 0.010399,
-     "end_time": "2023-10-26T14:58:02.902914",
+     "duration": 0.008002,
+     "end_time": "2023-10-27T01:51:51.341171",
      "exception": false,
-     "start_time": "2023-10-26T14:58:02.892515",
+     "start_time": "2023-10-27T01:51:51.333169",
      "status": "completed"
     },
     "tags": []
@@ -2822,14 +2822,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.067296,
-   "end_time": "2023-10-26T14:58:03.522635",
+   "duration": 33.670011,
+   "end_time": "2023-10-27T01:51:51.858885",
    "environment_variables": {},
    "exception": null,
    "input_path": "/content/notebooks/getting_started/part2_searching_basics.ipynb",
    "output_path": "/content/test/outputs/part2_searching_basics_papermill_output.ipynb",
    "parameters": {},
-   "start_time": "2023-10-26T14:57:30.455339",
+   "start_time": "2023-10-27T01:51:18.188874",
    "version": "2.4.0"
   }
  },

--- a/test/outputs/part3_exploring_cohorts_papermill_output.ipynb
+++ b/test/outputs/part3_exploring_cohorts_papermill_output.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "16212795",
+   "id": "3358ea4d",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github",
     "papermill": {
-     "duration": 0.017236,
-     "end_time": "2023-10-27T01:52:02.071546",
+     "duration": 0.014296,
+     "end_time": "2023-10-27T12:42:18.843692",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.054310",
+     "start_time": "2023-10-27T12:42:18.829396",
      "status": "completed"
     },
     "tags": []
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94726119",
+   "id": "7a63d55f",
    "metadata": {
     "id": "KmXfYFZtja2F",
     "papermill": {
-     "duration": 0.012848,
-     "end_time": "2023-10-27T01:52:02.098413",
+     "duration": 0.012163,
+     "end_time": "2023-10-27T12:42:18.869162",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.085565",
+     "start_time": "2023-10-27T12:42:18.856999",
      "status": "completed"
     },
     "tags": []
@@ -56,14 +56,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0919092f",
+   "id": "905ad084",
    "metadata": {
     "id": "07dGiFgK12BQ",
     "papermill": {
-     "duration": 0.01236,
-     "end_time": "2023-10-27T01:52:02.124119",
+     "duration": 0.011992,
+     "end_time": "2023-10-27T12:42:18.893087",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.111759",
+     "start_time": "2023-10-27T12:42:18.881095",
      "status": "completed"
     },
     "tags": []
@@ -76,14 +76,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05f23a84",
+   "id": "1f368373",
    "metadata": {
     "id": "8kHfbIFLIei-",
     "papermill": {
-     "duration": 0.012578,
-     "end_time": "2023-10-27T01:52:02.148809",
+     "duration": 0.012009,
+     "end_time": "2023-10-27T12:42:18.917134",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.136231",
+     "start_time": "2023-10-27T12:42:18.905125",
      "status": "completed"
     },
     "tags": []
@@ -101,20 +101,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ded860bc",
+   "id": "4435da54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:02.175606Z",
-     "iopub.status.busy": "2023-10-27T01:52:02.175106Z",
-     "iopub.status.idle": "2023-10-27T01:52:02.179073Z",
-     "shell.execute_reply": "2023-10-27T01:52:02.178374Z"
+     "iopub.execute_input": "2023-10-27T12:42:18.942441Z",
+     "iopub.status.busy": "2023-10-27T12:42:18.942102Z",
+     "iopub.status.idle": "2023-10-27T12:42:18.945706Z",
+     "shell.execute_reply": "2023-10-27T12:42:18.945105Z"
     },
     "id": "M3uMIzDYIirn",
     "papermill": {
-     "duration": 0.019729,
-     "end_time": "2023-10-27T01:52:02.180741",
+     "duration": 0.018259,
+     "end_time": "2023-10-27T12:42:18.947228",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.161012",
+     "start_time": "2023-10-27T12:42:18.928969",
      "status": "completed"
     },
     "tags": []
@@ -136,14 +136,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26bdb7da",
+   "id": "d2a11c2f",
    "metadata": {
     "id": "Ds1JM0-cIyry",
     "papermill": {
-     "duration": 0.012183,
-     "end_time": "2023-10-27T01:52:02.205622",
+     "duration": 0.012087,
+     "end_time": "2023-10-27T12:42:18.971538",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.193439",
+     "start_time": "2023-10-27T12:42:18.959451",
      "status": "completed"
     },
     "tags": []
@@ -163,14 +163,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "521e3dea",
+   "id": "23ae2fb0",
    "metadata": {
     "id": "Vpo2RqiuPnLn",
     "papermill": {
-     "duration": 0.011689,
-     "end_time": "2023-10-27T01:52:02.229931",
+     "duration": 0.011873,
+     "end_time": "2023-10-27T12:42:18.995319",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.218242",
+     "start_time": "2023-10-27T12:42:18.983446",
      "status": "completed"
     },
     "tags": []
@@ -184,20 +184,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "65eeb878",
+   "id": "f06a7e87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:02.257621Z",
-     "iopub.status.busy": "2023-10-27T01:52:02.257328Z",
-     "iopub.status.idle": "2023-10-27T01:52:06.608166Z",
-     "shell.execute_reply": "2023-10-27T01:52:06.607311Z"
+     "iopub.execute_input": "2023-10-27T12:42:19.020651Z",
+     "iopub.status.busy": "2023-10-27T12:42:19.020324Z",
+     "iopub.status.idle": "2023-10-27T12:42:23.121454Z",
+     "shell.execute_reply": "2023-10-27T12:42:23.120784Z"
     },
     "id": "sVBOII5GP9cw",
     "papermill": {
-     "duration": 4.366895,
-     "end_time": "2023-10-27T01:52:06.609810",
+     "duration": 4.115854,
+     "end_time": "2023-10-27T12:42:23.123110",
      "exception": false,
-     "start_time": "2023-10-27T01:52:02.242915",
+     "start_time": "2023-10-27T12:42:19.007256",
      "status": "completed"
     },
     "tags": []
@@ -207,7 +207,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-ac419fbd-c201-4355-8cee-4b3e34927c72\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-dc89d57c-1e92-478d-b51c-f34dc44920e2\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -305,7 +305,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ac419fbd-c201-4355-8cee-4b3e34927c72')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-dc89d57c-1e92-478d-b51c-f34dc44920e2')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -357,12 +357,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-ac419fbd-c201-4355-8cee-4b3e34927c72 button.colab-df-convert');\n",
+       "        document.querySelector('#df-dc89d57c-1e92-478d-b51c-f34dc44920e2 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-ac419fbd-c201-4355-8cee-4b3e34927c72');\n",
+       "        const element = document.querySelector('#df-dc89d57c-1e92-478d-b51c-f34dc44920e2');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -459,14 +459,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0875104f",
+   "id": "606bbf26",
    "metadata": {
     "id": "9Cl_ZOxqaaai",
     "papermill": {
-     "duration": 0.01277,
-     "end_time": "2023-10-27T01:52:06.636727",
+     "duration": 0.012818,
+     "end_time": "2023-10-27T12:42:23.148710",
      "exception": false,
-     "start_time": "2023-10-27T01:52:06.623957",
+     "start_time": "2023-10-27T12:42:23.135892",
      "status": "completed"
     },
     "tags": []
@@ -486,20 +486,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "87cd5a63",
+   "id": "c5f24d98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:06.663336Z",
-     "iopub.status.busy": "2023-10-27T01:52:06.662780Z",
-     "iopub.status.idle": "2023-10-27T01:52:10.044010Z",
-     "shell.execute_reply": "2023-10-27T01:52:10.042839Z"
+     "iopub.execute_input": "2023-10-27T12:42:23.175274Z",
+     "iopub.status.busy": "2023-10-27T12:42:23.174696Z",
+     "iopub.status.idle": "2023-10-27T12:42:26.247086Z",
+     "shell.execute_reply": "2023-10-27T12:42:26.246358Z"
     },
     "id": "D4dkFpEVfDO1",
     "papermill": {
-     "duration": 3.396538,
-     "end_time": "2023-10-27T01:52:10.045653",
+     "duration": 3.087827,
+     "end_time": "2023-10-27T12:42:26.248920",
      "exception": false,
-     "start_time": "2023-10-27T01:52:06.649115",
+     "start_time": "2023-10-27T12:42:23.161093",
      "status": "completed"
     },
     "tags": []
@@ -516,7 +516,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-16eae3b1-7897-41a0-a355-a60ed044f693\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-76f5180f-a511-446f-b2d2-728747a05981\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -614,7 +614,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-16eae3b1-7897-41a0-a355-a60ed044f693')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-76f5180f-a511-446f-b2d2-728747a05981')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -666,12 +666,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-16eae3b1-7897-41a0-a355-a60ed044f693 button.colab-df-convert');\n",
+       "        document.querySelector('#df-76f5180f-a511-446f-b2d2-728747a05981 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-16eae3b1-7897-41a0-a355-a60ed044f693');\n",
+       "        const element = document.querySelector('#df-76f5180f-a511-446f-b2d2-728747a05981');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -785,14 +785,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14af4946",
+   "id": "c664d224",
    "metadata": {
     "id": "ojgbk_nMhbv0",
     "papermill": {
-     "duration": 0.014404,
-     "end_time": "2023-10-27T01:52:10.073386",
+     "duration": 0.013842,
+     "end_time": "2023-10-27T12:42:26.277284",
      "exception": false,
-     "start_time": "2023-10-27T01:52:10.058982",
+     "start_time": "2023-10-27T12:42:26.263442",
      "status": "completed"
     },
     "tags": []
@@ -806,20 +806,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ec174583",
+   "id": "07b1ed72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:10.100222Z",
-     "iopub.status.busy": "2023-10-27T01:52:10.099911Z",
-     "iopub.status.idle": "2023-10-27T01:52:10.918019Z",
-     "shell.execute_reply": "2023-10-27T01:52:10.916994Z"
+     "iopub.execute_input": "2023-10-27T12:42:26.305456Z",
+     "iopub.status.busy": "2023-10-27T12:42:26.305137Z",
+     "iopub.status.idle": "2023-10-27T12:42:26.723123Z",
+     "shell.execute_reply": "2023-10-27T12:42:26.722501Z"
     },
     "id": "mr-F6YXrWHOm",
     "papermill": {
-     "duration": 0.834288,
-     "end_time": "2023-10-27T01:52:10.920285",
+     "duration": 0.43431,
+     "end_time": "2023-10-27T12:42:26.725131",
      "exception": false,
-     "start_time": "2023-10-27T01:52:10.085997",
+     "start_time": "2023-10-27T12:42:26.290821",
      "status": "completed"
     },
     "tags": []
@@ -829,7 +829,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2023-10-27 01:52:10--  https://github.com/peak/s5cmd/releases/download/v2.0.0/s5cmd_2.0.0_Linux-64bit.tar.gz\n",
+      "--2023-10-27 12:42:26--  https://github.com/peak/s5cmd/releases/download/v2.0.0/s5cmd_2.0.0_Linux-64bit.tar.gz\n",
       "Resolving github.com (github.com)... 140.82.113.4\n",
       "Connecting to github.com (github.com)|140.82.113.4|:443... connected.\n",
       "HTTP request sent, awaiting response... "
@@ -840,33 +840,19 @@
      "output_type": "stream",
      "text": [
       "302 Found\n",
-      "Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231027T015210Z&X-Amz-Expires=300&X-Amz-Signature=bca2fc80c71a54d31a82056a6ef24cb52402822de665488524b3742f2c3d40d4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream [following]\n",
-      "--2023-10-27 01:52:10--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231027T015210Z&X-Amz-Expires=300&X-Amz-Signature=bca2fc80c71a54d31a82056a6ef24cb52402822de665488524b3742f2c3d40d4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream\n",
-      "Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.109.133, 185.199.110.133, ...\n",
+      "Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231027T124226Z&X-Amz-Expires=300&X-Amz-Signature=02f074c76bc6b70901a8b87fd655ef3e012546a43d3af2a7f0d81e5d7db8d230&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream [following]\n",
+      "--2023-10-27 12:42:26--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231027T124226Z&X-Amz-Expires=300&X-Amz-Signature=02f074c76bc6b70901a8b87fd655ef3e012546a43d3af2a7f0d81e5d7db8d230&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream\n",
+      "Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...\n",
       "Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.\n",
-      "HTTP request sent, awaiting response... "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "200 OK\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 4276789 (4.1M) [application/octet-stream]\n",
       "Saving to: ‘s5cmd_2.0.0_Linux-64bit.tar.gz’\n",
       "\n",
       "\r",
-      "          s5cmd_2.0   0%[                    ]       0  --.-KB/s               "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "s5cmd_2.0.0_Linux-6 100%[===================>]   4.08M  24.7MB/s    in 0.2s    \n",
+      "          s5cmd_2.0   0%[                    ]       0  --.-KB/s               \r",
+      "s5cmd_2.0.0_Linux-6 100%[===================>]   4.08M  --.-KB/s    in 0.02s   \n",
       "\n",
-      "2023-10-27 01:52:10 (24.7 MB/s) - ‘s5cmd_2.0.0_Linux-64bit.tar.gz’ saved [4276789/4276789]\n",
+      "2023-10-27 12:42:26 (168 MB/s) - ‘s5cmd_2.0.0_Linux-64bit.tar.gz’ saved [4276789/4276789]\n",
       "\n"
      ]
     },
@@ -920,14 +906,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5fc5d6b",
+   "id": "7852e31f",
    "metadata": {
     "id": "gdrjpXYM--IH",
     "papermill": {
-     "duration": 0.013475,
-     "end_time": "2023-10-27T01:52:10.948089",
+     "duration": 0.013217,
+     "end_time": "2023-10-27T12:42:26.751865",
      "exception": false,
-     "start_time": "2023-10-27T01:52:10.934614",
+     "start_time": "2023-10-27T12:42:26.738648",
      "status": "completed"
     },
     "tags": []
@@ -939,20 +925,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "36ab55ed",
+   "id": "92ffac96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:11.001609Z",
-     "iopub.status.busy": "2023-10-27T01:52:11.001263Z",
-     "iopub.status.idle": "2023-10-27T01:52:14.077606Z",
-     "shell.execute_reply": "2023-10-27T01:52:14.076675Z"
+     "iopub.execute_input": "2023-10-27T12:42:26.809113Z",
+     "iopub.status.busy": "2023-10-27T12:42:26.808766Z",
+     "iopub.status.idle": "2023-10-27T12:42:29.918611Z",
+     "shell.execute_reply": "2023-10-27T12:42:29.917826Z"
     },
     "id": "gZhsxNbuWXy7",
     "papermill": {
-     "duration": 3.118158,
-     "end_time": "2023-10-27T01:52:14.079516",
+     "duration": 3.155874,
+     "end_time": "2023-10-27T12:42:29.920681",
      "exception": false,
-     "start_time": "2023-10-27T01:52:10.961358",
+     "start_time": "2023-10-27T12:42:26.764807",
      "status": "completed"
     },
     "tags": []
@@ -1010,14 +996,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102eb516",
+   "id": "9b7ede7c",
    "metadata": {
     "id": "M94EtV6jBnXg",
     "papermill": {
-     "duration": 0.014011,
-     "end_time": "2023-10-27T01:52:14.106030",
+     "duration": 0.013419,
+     "end_time": "2023-10-27T12:42:29.947886",
      "exception": false,
-     "start_time": "2023-10-27T01:52:14.092019",
+     "start_time": "2023-10-27T12:42:29.934467",
      "status": "completed"
     },
     "tags": []
@@ -1029,20 +1015,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b0dc0a1e",
+   "id": "1b98e261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:14.133262Z",
-     "iopub.status.busy": "2023-10-27T01:52:14.132925Z",
-     "iopub.status.idle": "2023-10-27T01:52:15.260914Z",
-     "shell.execute_reply": "2023-10-27T01:52:15.259379Z"
+     "iopub.execute_input": "2023-10-27T12:42:29.975810Z",
+     "iopub.status.busy": "2023-10-27T12:42:29.975467Z",
+     "iopub.status.idle": "2023-10-27T12:42:31.099739Z",
+     "shell.execute_reply": "2023-10-27T12:42:31.098791Z"
     },
     "id": "DvFRdvyPWpAE",
     "papermill": {
-     "duration": 1.143863,
-     "end_time": "2023-10-27T01:52:15.262882",
+     "duration": 1.140418,
+     "end_time": "2023-10-27T12:42:31.101466",
      "exception": false,
-     "start_time": "2023-10-27T01:52:14.119019",
+     "start_time": "2023-10-27T12:42:29.961048",
      "status": "completed"
     },
     "tags": []
@@ -1052,156 +1038,162 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
-      "cp s3://public-datasets-idc/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
-      "cp s3://public-datasets-idc/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
-      "cp s3://public-datasets-idc/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
-      "cp s3://public-datasets-idc/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
-      "cp s3://public-datasets-idc/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
-      "cp s3://public-datasets-idc/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
-      "cp s3://idc-open-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n"
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
-      "cp s3://public-datasets-idc/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
-      "cp s3://public-datasets-idc/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
-      "cp s3://public-datasets-idc/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
+      "cp s3://public-datasets-idc/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n",
+      "cp s3://public-datasets-idc/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
+      "cp s3://public-datasets-idc/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
+      "cp s3://public-datasets-idc/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
+      "cp s3://public-datasets-idc/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
+      "cp s3://idc-open-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
+      "cp s3://public-datasets-idc/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
+      "cp s3://public-datasets-idc/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cp s3://public-datasets-idc/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
+      "cp s3://public-datasets-idc/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n",
       "cp s3://idc-open-cr/acabf2ce-1b29-4ae9-87ec-528c196cb1c0/e2db7522-d068-427d-9e3a-e01c02beafb3.dcm e2db7522-d068-427d-9e3a-e01c02beafb3.dcm\n"
      ]
     }
@@ -1217,20 +1209,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "601f654a",
+   "id": "8ee8b6c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:15.294195Z",
-     "iopub.status.busy": "2023-10-27T01:52:15.293911Z",
-     "iopub.status.idle": "2023-10-27T01:52:16.821350Z",
-     "shell.execute_reply": "2023-10-27T01:52:16.820630Z"
+     "iopub.execute_input": "2023-10-27T12:42:31.131463Z",
+     "iopub.status.busy": "2023-10-27T12:42:31.131137Z",
+     "iopub.status.idle": "2023-10-27T12:42:32.051748Z",
+     "shell.execute_reply": "2023-10-27T12:42:32.050947Z"
     },
     "id": "e6BjWfTTC5kS",
     "papermill": {
-     "duration": 1.546208,
-     "end_time": "2023-10-27T01:52:16.823619",
+     "duration": 0.937376,
+     "end_time": "2023-10-27T12:42:32.053471",
      "exception": false,
-     "start_time": "2023-10-27T01:52:15.277411",
+     "start_time": "2023-10-27T12:42:31.116095",
      "status": "completed"
     },
     "tags": []
@@ -1240,174 +1232,162 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
-      "cp s3://idc-open-data/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
-      "cp s3://idc-open-data/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
-      "cp s3://idc-open-data/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
-      "cp s3://idc-open-data/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
-      "cp s3://idc-open-data/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
-      "cp s3://idc-open-data/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
-      "cp s3://idc-open-data/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
+      "cp s3://idc-open-data/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n",
+      "cp s3://idc-open-data/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
+      "cp s3://idc-open-data/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
+      "cp s3://idc-open-data/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
+      "cp s3://idc-open-data/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
+      "cp s3://idc-open-data/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
+      "cp s3://idc-open-data/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
-      "cp s3://idc-open-data-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
-      "cp s3://idc-open-data/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
-      "cp s3://idc-open-data/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n"
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
+      "cp s3://idc-open-data/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
+      "cp s3://idc-open-data-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "cp s3://idc-open-data/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
       "cp s3://idc-open-data-cr/acabf2ce-1b29-4ae9-87ec-528c196cb1c0/e2db7522-d068-427d-9e3a-e01c02beafb3.dcm e2db7522-d068-427d-9e3a-e01c02beafb3.dcm\n"
      ]
     }
@@ -1422,14 +1402,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87cfddc6",
+   "id": "71a60ca7",
    "metadata": {
     "id": "7LjNNakzVKvV",
     "papermill": {
-     "duration": 0.0189,
-     "end_time": "2023-10-27T01:52:16.857239",
+     "duration": 0.014537,
+     "end_time": "2023-10-27T12:42:32.083177",
      "exception": false,
-     "start_time": "2023-10-27T01:52:16.838339",
+     "start_time": "2023-10-27T12:42:32.068640",
      "status": "completed"
     },
     "tags": []
@@ -1450,25 +1430,25 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ff4baf1b",
+   "id": "84139d90",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 206
     },
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:16.886428Z",
-     "iopub.status.busy": "2023-10-27T01:52:16.886115Z",
-     "iopub.status.idle": "2023-10-27T01:52:20.468186Z",
-     "shell.execute_reply": "2023-10-27T01:52:20.467249Z"
+     "iopub.execute_input": "2023-10-27T12:42:32.112812Z",
+     "iopub.status.busy": "2023-10-27T12:42:32.112484Z",
+     "iopub.status.idle": "2023-10-27T12:42:35.511054Z",
+     "shell.execute_reply": "2023-10-27T12:42:35.510391Z"
     },
     "id": "bW5ULTmfpa7g",
     "outputId": "536ed0ec-1816-4604-e1bc-7cb221c5015f",
     "papermill": {
-     "duration": 3.598813,
-     "end_time": "2023-10-27T01:52:20.470397",
+     "duration": 3.415385,
+     "end_time": "2023-10-27T12:42:35.512595",
      "exception": false,
-     "start_time": "2023-10-27T01:52:16.871584",
+     "start_time": "2023-10-27T12:42:32.097210",
      "status": "completed"
     },
     "tags": []
@@ -1478,7 +1458,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-036e75a2-7744-42ad-91e9-1956b40c1303\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-ec81de9c-4db7-499d-a2cd-2357b0a7bdcd\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1566,7 +1546,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-036e75a2-7744-42ad-91e9-1956b40c1303')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ec81de9c-4db7-499d-a2cd-2357b0a7bdcd')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1618,12 +1598,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-036e75a2-7744-42ad-91e9-1956b40c1303 button.colab-df-convert');\n",
+       "        document.querySelector('#df-ec81de9c-4db7-499d-a2cd-2357b0a7bdcd button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-036e75a2-7744-42ad-91e9-1956b40c1303');\n",
+       "        const element = document.querySelector('#df-ec81de9c-4db7-499d-a2cd-2357b0a7bdcd');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1740,14 +1720,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2dbc1c1",
+   "id": "fc2eebce",
    "metadata": {
     "id": "JkUqWsLVprGU",
     "papermill": {
-     "duration": 0.014805,
-     "end_time": "2023-10-27T01:52:20.501810",
+     "duration": 0.014723,
+     "end_time": "2023-10-27T12:42:35.542249",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.487005",
+     "start_time": "2023-10-27T12:42:35.527526",
      "status": "completed"
     },
     "tags": []
@@ -1759,20 +1739,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "412631de",
+   "id": "63d8ba95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:20.532042Z",
-     "iopub.status.busy": "2023-10-27T01:52:20.531716Z",
-     "iopub.status.idle": "2023-10-27T01:52:20.537273Z",
-     "shell.execute_reply": "2023-10-27T01:52:20.536517Z"
+     "iopub.execute_input": "2023-10-27T12:42:35.572483Z",
+     "iopub.status.busy": "2023-10-27T12:42:35.572155Z",
+     "iopub.status.idle": "2023-10-27T12:42:35.577148Z",
+     "shell.execute_reply": "2023-10-27T12:42:35.576609Z"
     },
     "id": "rmEGwPyUqrYr",
     "papermill": {
-     "duration": 0.023471,
-     "end_time": "2023-10-27T01:52:20.539221",
+     "duration": 0.022731,
+     "end_time": "2023-10-27T12:42:35.579302",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.515750",
+     "start_time": "2023-10-27T12:42:35.556571",
      "status": "completed"
     },
     "tags": []
@@ -1803,14 +1783,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "854eaf2b",
+   "id": "fb522015",
    "metadata": {
     "id": "_tlbgnncq92y",
     "papermill": {
-     "duration": 0.014225,
-     "end_time": "2023-10-27T01:52:20.568581",
+     "duration": 0.014578,
+     "end_time": "2023-10-27T12:42:35.608380",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.554356",
+     "start_time": "2023-10-27T12:42:35.593802",
      "status": "completed"
     },
     "tags": []
@@ -1825,14 +1805,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "563036c8",
+   "id": "57ba0444",
    "metadata": {
     "id": "ZmL8qyT6StGt",
     "papermill": {
-     "duration": 0.013679,
-     "end_time": "2023-10-27T01:52:20.595884",
+     "duration": 0.015317,
+     "end_time": "2023-10-27T12:42:35.639454",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.582205",
+     "start_time": "2023-10-27T12:42:35.624137",
      "status": "completed"
     },
     "tags": []
@@ -1845,14 +1825,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93cd6441",
+   "id": "9f544e3f",
    "metadata": {
     "id": "sf8Iu3ZPJAmX",
     "papermill": {
-     "duration": 0.014682,
-     "end_time": "2023-10-27T01:52:20.625905",
+     "duration": 0.014497,
+     "end_time": "2023-10-27T12:42:35.668677",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.611223",
+     "start_time": "2023-10-27T12:42:35.654180",
      "status": "completed"
     },
     "tags": []
@@ -1868,24 +1848,24 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a56d5af5",
+   "id": "710b45d1",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:20.657672Z",
-     "iopub.status.busy": "2023-10-27T01:52:20.657156Z",
-     "iopub.status.idle": "2023-10-27T01:52:20.663590Z",
-     "shell.execute_reply": "2023-10-27T01:52:20.662768Z"
+     "iopub.execute_input": "2023-10-27T12:42:35.698851Z",
+     "iopub.status.busy": "2023-10-27T12:42:35.698532Z",
+     "iopub.status.idle": "2023-10-27T12:42:35.703002Z",
+     "shell.execute_reply": "2023-10-27T12:42:35.701847Z"
     },
     "id": "JVIqa3GWUV64",
     "outputId": "85d71354-1c2e-4ae9-8c7a-90828c7b72cb",
     "papermill": {
-     "duration": 0.024489,
-     "end_time": "2023-10-27T01:52:20.665164",
+     "duration": 0.021315,
+     "end_time": "2023-10-27T12:42:35.704417",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.640675",
+     "start_time": "2023-10-27T12:42:35.683102",
      "status": "completed"
     },
     "tags": []
@@ -1908,14 +1888,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49e43368",
+   "id": "8a138f2a",
    "metadata": {
     "id": "AkDL5e6bqSEa",
     "papermill": {
-     "duration": 0.017369,
-     "end_time": "2023-10-27T01:52:20.696769",
+     "duration": 0.014451,
+     "end_time": "2023-10-27T12:42:35.733311",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.679400",
+     "start_time": "2023-10-27T12:42:35.718860",
      "status": "completed"
     },
     "tags": []
@@ -1938,7 +1918,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a0e00604",
+   "id": "95f5f0a3",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1969,18 +1949,18 @@
      ]
     },
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:20.729250Z",
-     "iopub.status.busy": "2023-10-27T01:52:20.728930Z",
-     "iopub.status.idle": "2023-10-27T01:52:25.460714Z",
-     "shell.execute_reply": "2023-10-27T01:52:25.459878Z"
+     "iopub.execute_input": "2023-10-27T12:42:35.764208Z",
+     "iopub.status.busy": "2023-10-27T12:42:35.763872Z",
+     "iopub.status.idle": "2023-10-27T12:42:41.088312Z",
+     "shell.execute_reply": "2023-10-27T12:42:41.087616Z"
     },
     "id": "_gKhp0yruoIQ",
     "outputId": "f08bc23d-8c29-4284-e6a9-d4ddb1103616",
     "papermill": {
-     "duration": 4.749803,
-     "end_time": "2023-10-27T01:52:25.462491",
+     "duration": 5.34206,
+     "end_time": "2023-10-27T12:42:41.089964",
      "exception": false,
-     "start_time": "2023-10-27T01:52:20.712688",
+     "start_time": "2023-10-27T12:42:35.747904",
      "status": "completed"
     },
     "tags": []
@@ -1989,7 +1969,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f7da54fe6529416c84eebc19eca68375",
+       "model_id": "215b0a0f38904919bea90b299b8bd8fb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2003,7 +1983,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a561963e86f84c008f62d3a39e32f00a",
+       "model_id": "89e2b582d2fe492894a94f51daaa5d25",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2033,24 +2013,24 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3c0b364a",
+   "id": "16785ba3",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:25.496593Z",
-     "iopub.status.busy": "2023-10-27T01:52:25.496306Z",
-     "iopub.status.idle": "2023-10-27T01:52:25.501031Z",
-     "shell.execute_reply": "2023-10-27T01:52:25.500254Z"
+     "iopub.execute_input": "2023-10-27T12:42:41.122454Z",
+     "iopub.status.busy": "2023-10-27T12:42:41.122123Z",
+     "iopub.status.idle": "2023-10-27T12:42:41.126639Z",
+     "shell.execute_reply": "2023-10-27T12:42:41.125942Z"
     },
     "id": "eXITO1mauy7x",
     "outputId": "ffdb16cd-5f00-4514-8d86-6d2450590cca",
     "papermill": {
-     "duration": 0.023194,
-     "end_time": "2023-10-27T01:52:25.502724",
+     "duration": 0.022661,
+     "end_time": "2023-10-27T12:42:41.128130",
      "exception": false,
-     "start_time": "2023-10-27T01:52:25.479530",
+     "start_time": "2023-10-27T12:42:41.105469",
      "status": "completed"
     },
     "tags": []
@@ -2060,11 +2040,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://volview.kitware.app/?urls=s3://idc-open-data/2547454a-449e-4032-9b07-557700810d32\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/1f0a6f79-18e5-4971-918a-fcc65d5d013d\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/8df03fe8-e6a9-40db-a4bf-5105399675db\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/58165473-4391-4291-a6e8-759570d29efc\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/b1ed1cc3-26d6-465a-a1da-a218421d3a55\n"
+      "https://volview.kitware.app/?urls=s3://idc-open-data/6bb81971-78d9-4cde-b39f-b68179b26ad9\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/f1933a1c-d2fd-4892-b1a1-ed64ef076de1\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/e3ad8de3-c1ca-41fc-995e-dd21962c2cd6\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/a16f4864-f61c-4ddc-9810-951efbf6a521\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/dea07032-a47b-4fb9-befb-48254a9ed138\n"
      ]
     }
    ],
@@ -2075,14 +2055,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ae91868",
+   "id": "35b87781",
    "metadata": {
     "id": "SSNXGczneqMw",
     "papermill": {
-     "duration": 0.01636,
-     "end_time": "2023-10-27T01:52:25.535402",
+     "duration": 0.015066,
+     "end_time": "2023-10-27T12:42:41.158399",
      "exception": false,
-     "start_time": "2023-10-27T01:52:25.519042",
+     "start_time": "2023-10-27T12:42:41.143333",
      "status": "completed"
     },
     "tags": []
@@ -2097,14 +2077,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31f74c62",
+   "id": "61508d40",
    "metadata": {
     "id": "-zRHvX1ZK-Dn",
     "papermill": {
-     "duration": 0.015908,
-     "end_time": "2023-10-27T01:52:25.568147",
+     "duration": 0.014976,
+     "end_time": "2023-10-27T12:42:41.188822",
      "exception": false,
-     "start_time": "2023-10-27T01:52:25.552239",
+     "start_time": "2023-10-27T12:42:41.173846",
      "status": "completed"
     },
     "tags": []
@@ -2117,14 +2097,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49d5ff2b",
+   "id": "b6ed9780",
    "metadata": {
     "id": "pvcX4ZhS-OEu",
     "papermill": {
-     "duration": 0.015575,
-     "end_time": "2023-10-27T01:52:25.599173",
+     "duration": 0.015042,
+     "end_time": "2023-10-27T12:42:41.218993",
      "exception": false,
-     "start_time": "2023-10-27T01:52:25.583598",
+     "start_time": "2023-10-27T12:42:41.203951",
      "status": "completed"
     },
     "tags": []
@@ -2138,20 +2118,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "414b9b62",
+   "id": "43a4c264",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:25.633154Z",
-     "iopub.status.busy": "2023-10-27T01:52:25.632822Z",
-     "iopub.status.idle": "2023-10-27T01:52:26.147499Z",
-     "shell.execute_reply": "2023-10-27T01:52:26.146571Z"
+     "iopub.execute_input": "2023-10-27T12:42:41.251283Z",
+     "iopub.status.busy": "2023-10-27T12:42:41.250924Z",
+     "iopub.status.idle": "2023-10-27T12:42:41.561167Z",
+     "shell.execute_reply": "2023-10-27T12:42:41.559869Z"
     },
     "id": "Bx9snM-MK-v9",
     "papermill": {
-     "duration": 0.534993,
-     "end_time": "2023-10-27T01:52:26.149566",
+     "duration": 0.328772,
+     "end_time": "2023-10-27T12:42:41.562954",
      "exception": false,
-     "start_time": "2023-10-27T01:52:25.614573",
+     "start_time": "2023-10-27T12:42:41.234182",
      "status": "completed"
     },
     "tags": []
@@ -2343,7 +2323,7 @@
       "Receiving objects:  98% (166/169)\r",
       "Receiving objects:  99% (168/169)\r",
       "Receiving objects: 100% (169/169)\r",
-      "Receiving objects: 100% (169/169), 87.84 KiB | 2.58 MiB/s, done.\n",
+      "Receiving objects: 100% (169/169), 87.84 KiB | 17.57 MiB/s, done.\n",
       "Resolving deltas:   0% (0/86)\r",
       "Resolving deltas:   1% (1/86)\r",
       "Resolving deltas:   2% (2/86)\r",
@@ -2411,7 +2391,6 @@
       "Resolving deltas:  74% (64/86)\r",
       "Resolving deltas:  75% (65/86)\r",
       "Resolving deltas:  76% (66/86)\r",
-      "Resolving deltas:  77% (67/86)\r",
       "Resolving deltas:  79% (68/86)\r",
       "Resolving deltas:  80% (69/86)\r",
       "Resolving deltas:  81% (70/86)\r",
@@ -2444,20 +2423,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "6c498d34",
+   "id": "6005f159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:26.188792Z",
-     "iopub.status.busy": "2023-10-27T01:52:26.188385Z",
-     "iopub.status.idle": "2023-10-27T01:52:32.322767Z",
-     "shell.execute_reply": "2023-10-27T01:52:32.321885Z"
+     "iopub.execute_input": "2023-10-27T12:42:41.595893Z",
+     "iopub.status.busy": "2023-10-27T12:42:41.595553Z",
+     "iopub.status.idle": "2023-10-27T12:42:46.622598Z",
+     "shell.execute_reply": "2023-10-27T12:42:46.621567Z"
     },
     "id": "o9hS4wamM3jO",
     "papermill": {
-     "duration": 6.156665,
-     "end_time": "2023-10-27T01:52:32.324618",
+     "duration": 5.045438,
+     "end_time": "2023-10-27T12:42:46.624434",
      "exception": false,
-     "start_time": "2023-10-27T01:52:26.167953",
+     "start_time": "2023-10-27T12:42:41.578996",
      "status": "completed"
     },
     "tags": []
@@ -2468,11 +2447,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.1/1.8 MB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.6/1.8 MB\u001b[0m \u001b[31m9.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/1.8 MB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m \u001b[32m1.7/1.8 MB\u001b[0m \u001b[31m12.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m11.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.1/1.8 MB\u001b[0m \u001b[31m2.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.1/1.8 MB\u001b[0m \u001b[31m16.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m21.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     }
@@ -2483,14 +2460,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4e0e161",
+   "id": "50179138",
    "metadata": {
     "id": "8I7d2S5tpP19",
     "papermill": {
-     "duration": 0.01613,
-     "end_time": "2023-10-27T01:52:32.358241",
+     "duration": 0.015592,
+     "end_time": "2023-10-27T12:42:46.656671",
      "exception": false,
-     "start_time": "2023-10-27T01:52:32.342111",
+     "start_time": "2023-10-27T12:42:46.641079",
      "status": "completed"
     },
     "tags": []
@@ -2502,20 +2479,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "2b3abde4",
+   "id": "d4480a0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:32.392512Z",
-     "iopub.status.busy": "2023-10-27T01:52:32.392054Z",
-     "iopub.status.idle": "2023-10-27T01:52:34.820781Z",
-     "shell.execute_reply": "2023-10-27T01:52:34.819998Z"
+     "iopub.execute_input": "2023-10-27T12:42:46.690902Z",
+     "iopub.status.busy": "2023-10-27T12:42:46.690578Z",
+     "iopub.status.idle": "2023-10-27T12:42:48.619554Z",
+     "shell.execute_reply": "2023-10-27T12:42:48.618631Z"
     },
     "id": "QEPR3kszK_o-",
     "papermill": {
-     "duration": 2.448235,
-     "end_time": "2023-10-27T01:52:34.822547",
+     "duration": 1.948054,
+     "end_time": "2023-10-27T12:42:48.621212",
      "exception": false,
-     "start_time": "2023-10-27T01:52:32.374312",
+     "start_time": "2023-10-27T12:42:46.673158",
      "status": "completed"
     },
     "tags": []
@@ -2527,7 +2504,8 @@
      "text": [
       "\r",
       "  0% 0/145 [00:00<?, ?it/s]\r",
-      "  8% 12/145 [00:00<00:01, 118.21it/s]"
+      " 16% 23/145 [00:00<00:00, 228.53it/s]\r",
+      " 37% 53/145 [00:00<00:00, 191.32it/s]"
      ]
     },
     {
@@ -2535,7 +2513,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 37% 53/145 [00:00<00:00, 147.49it/s]"
+      " 59% 86/145 [00:00<00:00, 107.95it/s]"
      ]
     },
     {
@@ -2543,7 +2521,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 59% 86/145 [00:00<00:00, 83.19it/s] "
+      " 70% 101/145 [00:00<00:00, 86.82it/s]"
      ]
     },
     {
@@ -2551,7 +2529,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 67% 97/145 [00:01<00:00, 62.55it/s]"
+      " 82% 119/145 [00:01<00:00, 95.11it/s]"
      ]
     },
     {
@@ -2559,17 +2537,8 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 82% 119/145 [00:01<00:00, 74.50it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      " 88% 128/145 [00:01<00:00, 68.06it/s]\r",
-      " 94% 136/145 [00:01<00:00, 62.84it/s]\r",
-      "100% 145/145 [00:01<00:00, 77.41it/s]\n",
+      " 90% 131/145 [00:01<00:00, 74.76it/s]\r",
+      "100% 145/145 [00:01<00:00, 101.32it/s]\n",
       "Files sorted\n"
      ]
     }
@@ -2582,14 +2551,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2a14a48",
+   "id": "b3be1839",
    "metadata": {
     "id": "3iJRergFLgaf",
     "papermill": {
-     "duration": 0.017305,
-     "end_time": "2023-10-27T01:52:34.856491",
+     "duration": 0.016303,
+     "end_time": "2023-10-27T12:42:48.653770",
      "exception": false,
-     "start_time": "2023-10-27T01:52:34.839186",
+     "start_time": "2023-10-27T12:42:48.637467",
      "status": "completed"
     },
     "tags": []
@@ -2601,20 +2570,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f615ae59",
+   "id": "a2de7ba6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:52:34.890136Z",
-     "iopub.status.busy": "2023-10-27T01:52:34.889858Z",
-     "iopub.status.idle": "2023-10-27T01:53:21.943159Z",
-     "shell.execute_reply": "2023-10-27T01:53:21.942064Z"
+     "iopub.execute_input": "2023-10-27T12:42:48.686990Z",
+     "iopub.status.busy": "2023-10-27T12:42:48.686678Z",
+     "iopub.status.idle": "2023-10-27T12:43:23.162426Z",
+     "shell.execute_reply": "2023-10-27T12:43:23.161477Z"
     },
     "id": "Db18CEtoK_Md",
     "papermill": {
-     "duration": 47.073965,
-     "end_time": "2023-10-27T01:53:21.945785",
+     "duration": 34.494332,
+     "end_time": "2023-10-27T12:43:23.164276",
      "exception": false,
-     "start_time": "2023-10-27T01:52:34.871820",
+     "start_time": "2023-10-27T12:42:48.669944",
      "status": "completed"
     },
     "tags": []
@@ -2625,11 +2594,10 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/25.6 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.2/25.6 MB\u001b[0m \u001b[31m7.4 MB/s\u001b[0m eta \u001b[36m0:00:04\u001b[0m\r",
-      "\u001b[2K     \u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.6/25.6 MB\u001b[0m \u001b[31m8.4 MB/s\u001b[0m eta \u001b[36m0:00:03\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/25.6 MB\u001b[0m \u001b[31m9.9 MB/s\u001b[0m eta \u001b[36m0:00:03\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.5/25.6 MB\u001b[0m \u001b[31m11.0 MB/s\u001b[0m eta \u001b[36m0:00:03\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.1/25.6 MB\u001b[0m \u001b[31m12.0 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m"
+      "\u001b[2K     \u001b[91m━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.9/25.6 MB\u001b[0m \u001b[31m28.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.7/25.6 MB\u001b[0m \u001b[31m82.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.9/25.6 MB\u001b[0m \u001b[31m139.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.4/25.6 MB\u001b[0m \u001b[31m156.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2637,40 +2605,10 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.8/25.6 MB\u001b[0m \u001b[31m13.2 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.6/25.6 MB\u001b[0m \u001b[31m14.7 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/25.6 MB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/25.6 MB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/25.6 MB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.8/25.6 MB\u001b[0m \u001b[31m12.4 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.9/25.6 MB\u001b[0m \u001b[31m13.9 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.2/25.6 MB\u001b[0m \u001b[31m15.7 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.6/25.6 MB\u001b[0m \u001b[31m17.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.5/25.6 MB\u001b[0m \u001b[31m20.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.5/25.6 MB\u001b[0m \u001b[31m24.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.2/25.6 MB\u001b[0m \u001b[31m23.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.6/25.6 MB\u001b[0m \u001b[31m24.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.9/25.6 MB\u001b[0m \u001b[31m36.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m17.9/25.6 MB\u001b[0m \u001b[31m43.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m21.1/25.6 MB\u001b[0m \u001b[31m51.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.3/25.6 MB\u001b[0m \u001b[31m97.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m97.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m97.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.6/25.6 MB\u001b[0m \u001b[31m56.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m21.7/25.6 MB\u001b[0m \u001b[31m155.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m165.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m165.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.6/25.6 MB\u001b[0m \u001b[31m87.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2679,9 +2617,13 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/52.6 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/52.6 MB\u001b[0m \u001b[31m133.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/52.6 MB\u001b[0m \u001b[31m93.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.3/52.6 MB\u001b[0m \u001b[31m62.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.9/52.6 MB\u001b[0m \u001b[31m236.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m15.5/52.6 MB\u001b[0m \u001b[31m216.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m23.0/52.6 MB\u001b[0m \u001b[31m213.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m30.5/52.6 MB\u001b[0m \u001b[31m214.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m38.1/52.6 MB\u001b[0m \u001b[31m215.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m43.3/52.6 MB\u001b[0m \u001b[31m174.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━\u001b[0m \u001b[32m48.8/52.6 MB\u001b[0m \u001b[31m154.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2689,15 +2631,11 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.4/52.6 MB\u001b[0m \u001b[31m61.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.5/52.6 MB\u001b[0m \u001b[31m61.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m13.2/52.6 MB\u001b[0m \u001b[31m54.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m15.7/52.6 MB\u001b[0m \u001b[31m67.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m19.2/52.6 MB\u001b[0m \u001b[31m83.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m22.0/52.6 MB\u001b[0m \u001b[31m90.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m23.1/52.6 MB\u001b[0m \u001b[31m72.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.4/52.6 MB\u001b[0m \u001b[31m70.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m29.3/52.6 MB\u001b[0m \u001b[31m71.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2705,14 +2643,14 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m29.4/52.6 MB\u001b[0m \u001b[31m70.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m30.4/52.6 MB\u001b[0m \u001b[31m53.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━\u001b[0m \u001b[32m34.6/52.6 MB\u001b[0m \u001b[31m69.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m37.5/52.6 MB\u001b[0m \u001b[31m65.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m38.8/52.6 MB\u001b[0m \u001b[31m65.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m38.8/52.6 MB\u001b[0m \u001b[31m65.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━\u001b[0m \u001b[32m40.6/52.6 MB\u001b[0m \u001b[31m58.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m44.0/52.6 MB\u001b[0m \u001b[31m58.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2720,53 +2658,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━\u001b[0m \u001b[32m47.1/52.6 MB\u001b[0m \u001b[31m56.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m50.5/52.6 MB\u001b[0m \u001b[31m93.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m10.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m170.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m13.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2775,21 +2673,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 kB\u001b[0m \u001b[31m16.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/81.2 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/81.2 MB\u001b[0m \u001b[31m141.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.0/81.2 MB\u001b[0m \u001b[31m88.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.6/81.2 MB\u001b[0m \u001b[31m83.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.6/81.2 MB\u001b[0m \u001b[31m83.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m17.2/81.2 MB\u001b[0m \u001b[31m113.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m21.8/81.2 MB\u001b[0m \u001b[31m127.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 kB\u001b[0m \u001b[31m19.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/81.2 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.2/81.2 MB\u001b[0m \u001b[31m156.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.4/81.2 MB\u001b[0m \u001b[31m151.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m15.7/81.2 MB\u001b[0m \u001b[31m150.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2797,11 +2685,12 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.2/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.2/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.2/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m26.1/81.2 MB\u001b[0m \u001b[31m54.8 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m28.6/81.2 MB\u001b[0m \u001b[31m51.0 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m21.0/81.2 MB\u001b[0m \u001b[31m153.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m26.2/81.2 MB\u001b[0m \u001b[31m151.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m31.8/81.2 MB\u001b[0m \u001b[31m156.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m37.4/81.2 MB\u001b[0m \u001b[31m158.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m44.6/81.2 MB\u001b[0m \u001b[31m192.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m49.8/81.2 MB\u001b[0m \u001b[31m173.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2809,15 +2698,11 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m30.5/81.2 MB\u001b[0m \u001b[31m46.2 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m33.5/81.2 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m33.5/81.2 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m34.8/81.2 MB\u001b[0m \u001b[31m35.7 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m37.7/81.2 MB\u001b[0m \u001b[31m59.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m39.2/81.2 MB\u001b[0m \u001b[31m49.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.5/81.2 MB\u001b[0m \u001b[31m51.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.8/81.2 MB\u001b[0m \u001b[31m76.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.1/81.2 MB\u001b[0m \u001b[31m75.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m55.0/81.2 MB\u001b[0m \u001b[31m149.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m60.2/81.2 MB\u001b[0m \u001b[31m150.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━\u001b[0m \u001b[32m65.5/81.2 MB\u001b[0m \u001b[31m151.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m70.7/81.2 MB\u001b[0m \u001b[31m151.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━\u001b[0m \u001b[32m76.0/81.2 MB\u001b[0m \u001b[31m151.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2825,14 +2710,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.1/81.2 MB\u001b[0m \u001b[31m75.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.9/81.2 MB\u001b[0m \u001b[31m43.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━\u001b[0m \u001b[32m50.9/81.2 MB\u001b[0m \u001b[31m52.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m54.9/81.2 MB\u001b[0m \u001b[31m53.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m59.5/81.2 MB\u001b[0m \u001b[31m104.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━\u001b[0m \u001b[32m64.0/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━\u001b[0m \u001b[32m65.0/81.2 MB\u001b[0m \u001b[31m105.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m67.1/81.2 MB\u001b[0m \u001b[31m82.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2840,13 +2724,12 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m69.3/81.2 MB\u001b[0m \u001b[31m70.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━\u001b[0m \u001b[32m73.6/81.2 MB\u001b[0m \u001b[31m69.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m77.6/81.2 MB\u001b[0m \u001b[31m104.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m80.7/81.2 MB\u001b[0m \u001b[31m109.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2854,106 +2737,11 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m5.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m170.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m13.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2962,7 +2750,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/73.5 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m73.5/73.5 kB\u001b[0m \u001b[31m18.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m73.5/73.5 kB\u001b[0m \u001b[31m22.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2971,27 +2759,19 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/7.7 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/7.7 MB\u001b[0m \u001b[31m123.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m124.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m87.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━\u001b[0m \u001b[32m5.9/7.7 MB\u001b[0m \u001b[31m176.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m116.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/206.9 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/206.9 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m206.9/206.9 kB\u001b[0m \u001b[31m47.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/98.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m98.3/98.3 kB\u001b[0m \u001b[31m21.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m206.9/206.9 kB\u001b[0m \u001b[31m56.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/98.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m98.3/98.3 kB\u001b[0m \u001b[31m31.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3000,9 +2780,8 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/8.9 MB\u001b[0m \u001b[31m124.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━\u001b[0m \u001b[32m8.6/8.9 MB\u001b[0m \u001b[31m123.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m93.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━\u001b[0m \u001b[32m7.8/8.9 MB\u001b[0m \u001b[31m235.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m152.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3011,21 +2790,12 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/130.2 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m130.2/130.2 kB\u001b[0m \u001b[31m31.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/7.0 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/7.0 MB\u001b[0m \u001b[31m154.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/7.0 MB\u001b[0m \u001b[31m154.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/7.0 MB\u001b[0m \u001b[31m154.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.0/7.0 MB\u001b[0m \u001b[31m21.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m40.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m36.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m130.2/130.2 kB\u001b[0m \u001b[31m41.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/7.0 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m5.9/7.0 MB\u001b[0m \u001b[31m179.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m129.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/117.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m117.7/117.7 kB\u001b[0m \u001b[31m38.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3033,19 +2803,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/117.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m117.7/117.7 kB\u001b[0m \u001b[31m33.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/42.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.8/42.8 kB\u001b[0m \u001b[31m10.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m101.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/42.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.8/42.8 kB\u001b[0m \u001b[31m15.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m122.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3061,18 +2822,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/92.9 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m92.9/92.9 kB\u001b[0m \u001b[31m30.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/45.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.7/45.7 kB\u001b[0m \u001b[31m13.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m92.9/92.9 kB\u001b[0m \u001b[31m30.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/45.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.7/45.7 kB\u001b[0m \u001b[31m15.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/59.5 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.5/59.5 kB\u001b[0m \u001b[31m17.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.5/59.5 kB\u001b[0m \u001b[31m19.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3080,15 +2834,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.2 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 kB\u001b[0m \u001b[31m14.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 kB\u001b[0m \u001b[31m18.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3097,7 +2845,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/86.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m86.0/86.0 kB\u001b[0m \u001b[31m28.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m86.0/86.0 kB\u001b[0m \u001b[31m32.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3113,11 +2861,50 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/12.3 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/12.3 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.1/12.3 MB\u001b[0m \u001b[31m103.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m10.5/12.3 MB\u001b[0m \u001b[31m110.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m97.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m76.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.1/12.3 MB\u001b[0m \u001b[31m155.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━\u001b[0m \u001b[32m11.5/12.3 MB\u001b[0m \u001b[31m169.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m169.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m12.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3126,7 +2913,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/67.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m67.0/67.0 kB\u001b[0m \u001b[31m22.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m67.0/67.0 kB\u001b[0m \u001b[31m22.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3135,9 +2922,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/58.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m16.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m22.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/341.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.4/341.4 kB\u001b[0m \u001b[31m64.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.4/341.4 kB\u001b[0m \u001b[31m73.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/3.4 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.4/3.4 MB\u001b[0m \u001b[31m131.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3145,10 +2934,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/3.4 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.4/3.4 MB\u001b[0m \u001b[31m109.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.3 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m54.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.3 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m130.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3157,41 +2944,32 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.7 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.7/1.7 MB\u001b[0m \u001b[31m101.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.7/1.7 MB\u001b[0m \u001b[31m120.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m17.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m19.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m16.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.0/57.0 kB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m18.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.0/57.0 kB\u001b[0m \u001b[31m18.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.1 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.1/57.1 kB\u001b[0m \u001b[31m17.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.8/56.8 kB\u001b[0m \u001b[31m16.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.1/57.1 kB\u001b[0m \u001b[31m19.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.8/56.8 kB\u001b[0m \u001b[31m19.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.7/56.7 kB\u001b[0m \u001b[31m19.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.7/56.7 kB\u001b[0m \u001b[31m17.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m17.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.5/8.9 MB\u001b[0m \u001b[31m103.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m7.3/8.9 MB\u001b[0m \u001b[31m107.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m86.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m18.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/8.9 MB\u001b[0m \u001b[31m151.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m7.7/8.9 MB\u001b[0m \u001b[31m230.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m150.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
      ]
     },
     {
@@ -3199,13 +2977,25 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.3/8.9 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m6.3/8.9 MB\u001b[0m \u001b[31m61.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m \u001b[32m8.7/8.9 MB\u001b[0m \u001b[31m62.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m54.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.7/8.9 MB\u001b[0m \u001b[31m170.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m177.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m125.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.4/8.9 MB\u001b[0m \u001b[31m131.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m7.4/8.9 MB\u001b[0m \u001b[31m107.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/8.9 MB\u001b[0m \u001b[31m159.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m173.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m124.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━\u001b[0m \u001b[32m8.2/8.9 MB\u001b[0m \u001b[31m227.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m151.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.4/8.9 MB\u001b[0m \u001b[31m164.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -3213,36 +3003,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m86.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m171.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m125.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/8.9 MB\u001b[0m \u001b[31m125.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m8.5/8.9 MB\u001b[0m \u001b[31m123.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m93.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.5/8.9 MB\u001b[0m \u001b[31m44.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━\u001b[0m \u001b[32m5.9/8.9 MB\u001b[0m \u001b[31m85.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m96.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m77.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/8.9 MB\u001b[0m \u001b[31m126.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━\u001b[0m \u001b[32m8.3/8.9 MB\u001b[0m \u001b[31m122.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m94.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m6.3/8.9 MB\u001b[0m \u001b[31m190.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m133.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/8.8 MB\u001b[0m \u001b[31m110.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m7.3/8.8 MB\u001b[0m \u001b[31m225.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -3250,23 +3017,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/8.8 MB\u001b[0m \u001b[31m77.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m6.3/8.8 MB\u001b[0m \u001b[31m80.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m66.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m57.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m146.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m14.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m18.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/55.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m55.4/55.4 kB\u001b[0m \u001b[31m14.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/54.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m54.8/54.8 kB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m55.4/55.4 kB\u001b[0m \u001b[31m18.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/54.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m54.8/54.8 kB\u001b[0m \u001b[31m19.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3275,7 +3032,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/341.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.8/341.8 kB\u001b[0m \u001b[31m56.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.8/341.8 kB\u001b[0m \u001b[31m80.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3284,7 +3041,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.6 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m90.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m121.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3328,20 +3085,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "a581447e",
+   "id": "43620dec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:53:21.990259Z",
-     "iopub.status.busy": "2023-10-27T01:53:21.989908Z",
-     "iopub.status.idle": "2023-10-27T01:53:27.824325Z",
-     "shell.execute_reply": "2023-10-27T01:53:27.823186Z"
+     "iopub.execute_input": "2023-10-27T12:43:23.202713Z",
+     "iopub.status.busy": "2023-10-27T12:43:23.202407Z",
+     "iopub.status.idle": "2023-10-27T12:43:27.699220Z",
+     "shell.execute_reply": "2023-10-27T12:43:27.698455Z"
     },
     "id": "FksVuvkgLbpG",
     "papermill": {
-     "duration": 5.85871,
-     "end_time": "2023-10-27T01:53:27.826838",
+     "duration": 4.518189,
+     "end_time": "2023-10-27T12:43:27.701137",
      "exception": false,
-     "start_time": "2023-10-27T01:53:21.968128",
+     "start_time": "2023-10-27T12:43:23.182948",
      "status": "completed"
     },
     "tags": []
@@ -3358,14 +3115,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba95044b",
+   "id": "2a16ce7a",
    "metadata": {
     "id": "-KttG3eOLlxg",
     "papermill": {
-     "duration": 0.022376,
-     "end_time": "2023-10-27T01:53:27.871880",
+     "duration": 0.01863,
+     "end_time": "2023-10-27T12:43:27.738392",
      "exception": false,
-     "start_time": "2023-10-27T01:53:27.849504",
+     "start_time": "2023-10-27T12:43:27.719762",
      "status": "completed"
     },
     "tags": []
@@ -3377,20 +3134,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "e15a30ef",
+   "id": "08d4d784",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:53:27.915444Z",
-     "iopub.status.busy": "2023-10-27T01:53:27.914538Z",
-     "iopub.status.idle": "2023-10-27T01:53:30.893334Z",
-     "shell.execute_reply": "2023-10-27T01:53:30.892325Z"
+     "iopub.execute_input": "2023-10-27T12:43:27.776517Z",
+     "iopub.status.busy": "2023-10-27T12:43:27.775688Z",
+     "iopub.status.idle": "2023-10-27T12:43:30.014190Z",
+     "shell.execute_reply": "2023-10-27T12:43:30.013279Z"
     },
     "id": "dtNEiziLLlWv",
     "papermill": {
-     "duration": 3.003491,
-     "end_time": "2023-10-27T01:53:30.895627",
+     "duration": 2.259997,
+     "end_time": "2023-10-27T12:43:30.016280",
      "exception": false,
-     "start_time": "2023-10-27T01:53:27.892136",
+     "start_time": "2023-10-27T12:43:27.756283",
      "status": "completed"
     },
     "tags": []
@@ -3405,20 +3162,20 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "59aee5fd",
+   "id": "1d54e455",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:53:30.939904Z",
-     "iopub.status.busy": "2023-10-27T01:53:30.939557Z",
-     "iopub.status.idle": "2023-10-27T01:53:33.646122Z",
-     "shell.execute_reply": "2023-10-27T01:53:33.645255Z"
+     "iopub.execute_input": "2023-10-27T12:43:30.060079Z",
+     "iopub.status.busy": "2023-10-27T12:43:30.059724Z",
+     "iopub.status.idle": "2023-10-27T12:43:33.670747Z",
+     "shell.execute_reply": "2023-10-27T12:43:33.669978Z"
     },
     "id": "Rvf1sEizLwyR",
     "papermill": {
-     "duration": 2.730492,
-     "end_time": "2023-10-27T01:53:33.648354",
+     "duration": 3.637516,
+     "end_time": "2023-10-27T12:43:33.672961",
      "exception": false,
-     "start_time": "2023-10-27T01:53:30.917862",
+     "start_time": "2023-10-27T12:43:30.035445",
      "status": "completed"
     },
     "tags": []
@@ -3448,25 +3205,25 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "6fc3f54f",
+   "id": "4beadfee",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 567
     },
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:53:33.692480Z",
-     "iopub.status.busy": "2023-10-27T01:53:33.692155Z",
-     "iopub.status.idle": "2023-10-27T01:53:37.098428Z",
-     "shell.execute_reply": "2023-10-27T01:53:37.097528Z"
+     "iopub.execute_input": "2023-10-27T12:43:33.711731Z",
+     "iopub.status.busy": "2023-10-27T12:43:33.711361Z",
+     "iopub.status.idle": "2023-10-27T12:43:36.822999Z",
+     "shell.execute_reply": "2023-10-27T12:43:36.822292Z"
     },
     "id": "tiA1Da5iLuid",
     "outputId": "09fcd200-9db3-4472-a0ce-0e39f7fcee79",
     "papermill": {
-     "duration": 3.430528,
-     "end_time": "2023-10-27T01:53:37.100429",
+     "duration": 3.132957,
+     "end_time": "2023-10-27T12:43:36.824521",
      "exception": false,
-     "start_time": "2023-10-27T01:53:33.669901",
+     "start_time": "2023-10-27T12:43:33.691564",
      "status": "completed"
     },
     "tags": []
@@ -3833,7 +3590,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"653daa3c-4edb-410a-98e9-e9cb18ecfc8a\"></div>"
+       "<div id=\"14abcaf6-125c-4dde-9863-4efc3fffa93f\"></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -3849,14 +3606,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79454a58",
+   "id": "be61fbfc",
    "metadata": {
     "id": "_5LnamoiL6sf",
     "papermill": {
-     "duration": 0.022322,
-     "end_time": "2023-10-27T01:53:37.144908",
+     "duration": 0.018822,
+     "end_time": "2023-10-27T12:43:36.862879",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.122586",
+     "start_time": "2023-10-27T12:43:36.844057",
      "status": "completed"
     },
     "tags": []
@@ -3868,20 +3625,20 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "c7dabfef",
+   "id": "ef13ea71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:53:37.190861Z",
-     "iopub.status.busy": "2023-10-27T01:53:37.190475Z",
-     "iopub.status.idle": "2023-10-27T01:53:37.196385Z",
-     "shell.execute_reply": "2023-10-27T01:53:37.195127Z"
+     "iopub.execute_input": "2023-10-27T12:43:36.901990Z",
+     "iopub.status.busy": "2023-10-27T12:43:36.901347Z",
+     "iopub.status.idle": "2023-10-27T12:43:36.905593Z",
+     "shell.execute_reply": "2023-10-27T12:43:36.904947Z"
     },
     "id": "sUi81pCUL5_0",
     "papermill": {
-     "duration": 0.031868,
-     "end_time": "2023-10-27T01:53:37.198389",
+     "duration": 0.025527,
+     "end_time": "2023-10-27T12:43:36.907003",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.166521",
+     "start_time": "2023-10-27T12:43:36.881476",
      "status": "completed"
     },
     "tags": []
@@ -3894,14 +3651,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e2c2913",
+   "id": "a28f299b",
    "metadata": {
     "id": "QLfj3CutL5tV",
     "papermill": {
-     "duration": 0.022205,
-     "end_time": "2023-10-27T01:53:37.241599",
+     "duration": 0.018691,
+     "end_time": "2023-10-27T12:43:36.944299",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.219394",
+     "start_time": "2023-10-27T12:43:36.925608",
      "status": "completed"
     },
     "tags": []
@@ -3913,20 +3670,20 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "465494f5",
+   "id": "b5e7644d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-27T01:53:37.290412Z",
-     "iopub.status.busy": "2023-10-27T01:53:37.290043Z",
-     "iopub.status.idle": "2023-10-27T01:53:37.296771Z",
-     "shell.execute_reply": "2023-10-27T01:53:37.293642Z"
+     "iopub.execute_input": "2023-10-27T12:43:36.984723Z",
+     "iopub.status.busy": "2023-10-27T12:43:36.984397Z",
+     "iopub.status.idle": "2023-10-27T12:43:36.989300Z",
+     "shell.execute_reply": "2023-10-27T12:43:36.988653Z"
     },
     "id": "XSxs_YqeL6XW",
     "papermill": {
-     "duration": 0.035515,
-     "end_time": "2023-10-27T01:53:37.301169",
+     "duration": 0.02786,
+     "end_time": "2023-10-27T12:43:36.990852",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.265654",
+     "start_time": "2023-10-27T12:43:36.962992",
      "status": "completed"
     },
     "tags": []
@@ -3942,14 +3699,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b3be796",
+   "id": "d6f70818",
    "metadata": {
     "id": "w1PIlmOkdfqd",
     "papermill": {
-     "duration": 0.022222,
-     "end_time": "2023-10-27T01:53:37.345159",
+     "duration": 0.018496,
+     "end_time": "2023-10-27T12:43:37.028087",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.322937",
+     "start_time": "2023-10-27T12:43:37.009591",
      "status": "completed"
     },
     "tags": []
@@ -3962,14 +3719,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fe119f9",
+   "id": "c8876914",
    "metadata": {
     "id": "F1JKCw8IfYRE",
     "papermill": {
-     "duration": 0.021671,
-     "end_time": "2023-10-27T01:53:37.388377",
+     "duration": 0.020133,
+     "end_time": "2023-10-27T12:43:37.067389",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.366706",
+     "start_time": "2023-10-27T12:43:37.047256",
      "status": "completed"
     },
     "tags": []
@@ -3980,14 +3737,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e61750f",
+   "id": "7dc2f19b",
    "metadata": {
     "id": "gzMMpG4y6g-v",
     "papermill": {
-     "duration": 0.021077,
-     "end_time": "2023-10-27T01:53:37.430532",
+     "duration": 0.018852,
+     "end_time": "2023-10-27T12:43:37.106433",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.409455",
+     "start_time": "2023-10-27T12:43:37.087581",
      "status": "completed"
     },
     "tags": []
@@ -4000,14 +3757,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4969f36",
+   "id": "25fc50d5",
    "metadata": {
     "id": "NnuWgtK_vnWC",
     "papermill": {
-     "duration": 0.021625,
-     "end_time": "2023-10-27T01:53:37.473838",
+     "duration": 0.018712,
+     "end_time": "2023-10-27T12:43:37.143853",
      "exception": false,
-     "start_time": "2023-10-27T01:53:37.452213",
+     "start_time": "2023-10-27T12:43:37.125141",
      "status": "completed"
     },
     "tags": []
@@ -4048,20 +3805,20 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 99.512817,
-   "end_time": "2023-10-27T01:53:40.105122",
+   "duration": 82.21384,
+   "end_time": "2023-10-27T12:43:39.770641",
    "environment_variables": {},
    "exception": null,
    "input_path": "/content/notebooks/getting_started/part3_exploring_cohorts.ipynb",
    "output_path": "/content/test/outputs/part3_exploring_cohorts_papermill_output.ipynb",
    "parameters": {},
-   "start_time": "2023-10-27T01:52:00.592305",
+   "start_time": "2023-10-27T12:42:17.556801",
    "version": "2.4.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "06cdc428d88d49fba69d55e554be65f3": {
+     "025a4ab5f0da426aa772ef3f1c96539b": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -4113,7 +3870,7 @@
        "width": null
       }
      },
-     "22783d6d75704df8bc2274720b715e6f": {
+     "0cdedea195234cc39d5a0fd6d7687153": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -4128,75 +3885,7 @@
        "description_width": ""
       }
      },
-     "35053dd145f644f28092a68991ed24af": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "45cfd8bc995441f6a0cff2f7bf14dc04": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "5096f764cef5431cb69d81344da3355c": {
+     "1ea29abde45844458f4dcee3470d426c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "FloatProgressModel",
@@ -4212,222 +3901,15 @@
        "bar_style": "success",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_dde29fec82a341edb68e580f1b5ff3f6",
+       "layout": "IPY_MODEL_e4723942497c4c268c3b3df792c2e300",
        "max": 5.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_7a9c1fcaf118486d927684794260e896",
+       "style": "IPY_MODEL_73a5975752594fb1902538952421e7cd",
        "value": 5.0
       }
      },
-     "5834b1eabc8e42668e3f197867871888": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_bf177ad4c52341749a93cf509bdb08a9",
-       "placeholder": "​",
-       "style": "IPY_MODEL_22783d6d75704df8bc2274720b715e6f",
-       "value": "Downloading: 100%"
-      }
-     },
-     "6c8e6f332b71459daf671a1d974c2f79": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "6f926c3efd704de080942702436f4881": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_bc996bae90204a90914251b520a95cec",
-       "placeholder": "​",
-       "style": "IPY_MODEL_a44f825bf272408f8d1984a596a847c0",
-       "value": ""
-      }
-     },
-     "779c9e56c22f42879bbaaac085e9d679": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "7a9c1fcaf118486d927684794260e896": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "9b62aed324da417a9ed1cffbc4dc8859": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "9e11e2f11b624c59a04ac185c4273ed7": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "a44f825bf272408f8d1984a596a847c0": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
-      }
-     },
-     "a561963e86f84c008f62d3a39e32f00a": {
+     "215b0a0f38904919bea90b299b8bd8fb": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
@@ -4442,264 +3924,14 @@
        "_view_name": "HBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_5834b1eabc8e42668e3f197867871888",
-        "IPY_MODEL_5096f764cef5431cb69d81344da3355c",
-        "IPY_MODEL_e319bf1a5696472d9c07372a1326cf99"
+        "IPY_MODEL_903e80d248234de6af214ddcd63950a7",
+        "IPY_MODEL_28a6f72608f147b7839f1f5c94967b7a",
+        "IPY_MODEL_c7c1cae4569746a8b9062fe0bb84fd9e"
        ],
-       "layout": "IPY_MODEL_9e11e2f11b624c59a04ac185c4273ed7"
+       "layout": "IPY_MODEL_7a46920ed3d44cb0b7fc7641ed99c42c"
       }
      },
-     "ac5beee8815948e1a620b75e769f17e0": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_b4ab03ce812c4553afa92324aa7ea4a2",
-       "placeholder": "​",
-       "style": "IPY_MODEL_779c9e56c22f42879bbaaac085e9d679",
-       "value": "Job ID bd45ae24-e976-41fd-8277-89dbb03704fa successfully executed: 100%"
-      }
-     },
-     "b4ab03ce812c4553afa92324aa7ea4a2": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "bc996bae90204a90914251b520a95cec": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "bf177ad4c52341749a93cf509bdb08a9": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "dde29fec82a341edb68e580f1b5ff3f6": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "e319bf1a5696472d9c07372a1326cf99": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_35053dd145f644f28092a68991ed24af",
-       "placeholder": "​",
-       "style": "IPY_MODEL_6c8e6f332b71459daf671a1d974c2f79",
-       "value": ""
-      }
-     },
-     "eee5964fb92746e6bd9c578d1d613a1a": {
+     "28a6f72608f147b7839f1f5c94967b7a": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "FloatProgressModel",
@@ -4715,15 +3947,311 @@
        "bar_style": "success",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_9b62aed324da417a9ed1cffbc4dc8859",
+       "layout": "IPY_MODEL_d76d6ff5c68546278c127a6629cee480",
        "max": 1.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_45cfd8bc995441f6a0cff2f7bf14dc04",
+       "style": "IPY_MODEL_c543322afaf0499a84201579426f85e4",
        "value": 1.0
       }
      },
-     "f7da54fe6529416c84eebc19eca68375": {
+     "46bc1a073c154a51a6418862d4342d0c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4a97adfbef6b4aa781f567409bbea38c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "532dc331e4124124a3f624a2b493e01a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_57ce5b2aea9a4bb2a8de417727f28533",
+       "placeholder": "​",
+       "style": "IPY_MODEL_cc4a731f0d414da29b5f8ec50619c295",
+       "value": ""
+      }
+     },
+     "57ce5b2aea9a4bb2a8de417727f28533": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "5bfc5bd7ef464485a7f23556f318aa18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "73a5975752594fb1902538952421e7cd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "7a46920ed3d44cb0b7fc7641ed99c42c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "7ea76ffcdb904bb1ab46084360c259cf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_46bc1a073c154a51a6418862d4342d0c",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0cdedea195234cc39d5a0fd6d7687153",
+       "value": "Downloading: 100%"
+      }
+     },
+     "82f06519c5cc4fd6a511216ecdc34dad": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "89e2b582d2fe492894a94f51daaa5d25": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
@@ -4738,11 +4266,240 @@
        "_view_name": "HBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_ac5beee8815948e1a620b75e769f17e0",
-        "IPY_MODEL_eee5964fb92746e6bd9c578d1d613a1a",
-        "IPY_MODEL_6f926c3efd704de080942702436f4881"
+        "IPY_MODEL_7ea76ffcdb904bb1ab46084360c259cf",
+        "IPY_MODEL_1ea29abde45844458f4dcee3470d426c",
+        "IPY_MODEL_532dc331e4124124a3f624a2b493e01a"
        ],
-       "layout": "IPY_MODEL_06cdc428d88d49fba69d55e554be65f3"
+       "layout": "IPY_MODEL_025a4ab5f0da426aa772ef3f1c96539b"
+      }
+     },
+     "903e80d248234de6af214ddcd63950a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_82f06519c5cc4fd6a511216ecdc34dad",
+       "placeholder": "​",
+       "style": "IPY_MODEL_5bfc5bd7ef464485a7f23556f318aa18",
+       "value": "Job ID b71a5636-6284-41ce-9971-c494d675afd8 successfully executed: 100%"
+      }
+     },
+     "c543322afaf0499a84201579426f85e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "c7c1cae4569746a8b9062fe0bb84fd9e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_ed809d424da94af6b63b9b2dbe057805",
+       "placeholder": "​",
+       "style": "IPY_MODEL_4a97adfbef6b4aa781f567409bbea38c",
+       "value": ""
+      }
+     },
+     "cc4a731f0d414da29b5f8ec50619c295": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "d76d6ff5c68546278c127a6629cee480": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e4723942497c4c268c3b3df792c2e300": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ed809d424da94af6b63b9b2dbe057805": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
       }
      }
     },

--- a/test/outputs/part3_exploring_cohorts_papermill_output.ipynb
+++ b/test/outputs/part3_exploring_cohorts_papermill_output.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "355358f1",
+   "id": "16212795",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github",
     "papermill": {
-     "duration": 0.020997,
-     "end_time": "2023-10-26T14:58:14.296999",
+     "duration": 0.017236,
+     "end_time": "2023-10-27T01:52:02.071546",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.276002",
+     "start_time": "2023-10-27T01:52:02.054310",
      "status": "completed"
     },
     "tags": []
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3c95d52",
+   "id": "94726119",
    "metadata": {
     "id": "KmXfYFZtja2F",
     "papermill": {
-     "duration": 0.015087,
-     "end_time": "2023-10-26T14:58:14.328330",
+     "duration": 0.012848,
+     "end_time": "2023-10-27T01:52:02.098413",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.313243",
+     "start_time": "2023-10-27T01:52:02.085565",
      "status": "completed"
     },
     "tags": []
@@ -56,14 +56,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98fc6cef",
+   "id": "0919092f",
    "metadata": {
     "id": "07dGiFgK12BQ",
     "papermill": {
-     "duration": 0.014508,
-     "end_time": "2023-10-26T14:58:14.358011",
+     "duration": 0.01236,
+     "end_time": "2023-10-27T01:52:02.124119",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.343503",
+     "start_time": "2023-10-27T01:52:02.111759",
      "status": "completed"
     },
     "tags": []
@@ -76,14 +76,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d220470",
+   "id": "05f23a84",
    "metadata": {
     "id": "8kHfbIFLIei-",
     "papermill": {
-     "duration": 0.015736,
-     "end_time": "2023-10-26T14:58:14.388235",
+     "duration": 0.012578,
+     "end_time": "2023-10-27T01:52:02.148809",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.372499",
+     "start_time": "2023-10-27T01:52:02.136231",
      "status": "completed"
     },
     "tags": []
@@ -101,20 +101,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "cd5d4d4e",
+   "id": "ded860bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:14.418460Z",
-     "iopub.status.busy": "2023-10-26T14:58:14.418114Z",
-     "iopub.status.idle": "2023-10-26T14:58:14.423027Z",
-     "shell.execute_reply": "2023-10-26T14:58:14.421527Z"
+     "iopub.execute_input": "2023-10-27T01:52:02.175606Z",
+     "iopub.status.busy": "2023-10-27T01:52:02.175106Z",
+     "iopub.status.idle": "2023-10-27T01:52:02.179073Z",
+     "shell.execute_reply": "2023-10-27T01:52:02.178374Z"
     },
     "id": "M3uMIzDYIirn",
     "papermill": {
-     "duration": 0.022308,
-     "end_time": "2023-10-26T14:58:14.424822",
+     "duration": 0.019729,
+     "end_time": "2023-10-27T01:52:02.180741",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.402514",
+     "start_time": "2023-10-27T01:52:02.161012",
      "status": "completed"
     },
     "tags": []
@@ -136,14 +136,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a04888d",
+   "id": "26bdb7da",
    "metadata": {
     "id": "Ds1JM0-cIyry",
     "papermill": {
-     "duration": 0.014726,
-     "end_time": "2023-10-26T14:58:14.454119",
+     "duration": 0.012183,
+     "end_time": "2023-10-27T01:52:02.205622",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.439393",
+     "start_time": "2023-10-27T01:52:02.193439",
      "status": "completed"
     },
     "tags": []
@@ -163,14 +163,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66b43bb7",
+   "id": "521e3dea",
    "metadata": {
     "id": "Vpo2RqiuPnLn",
     "papermill": {
-     "duration": 0.014302,
-     "end_time": "2023-10-26T14:58:14.482657",
+     "duration": 0.011689,
+     "end_time": "2023-10-27T01:52:02.229931",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.468355",
+     "start_time": "2023-10-27T01:52:02.218242",
      "status": "completed"
     },
     "tags": []
@@ -184,20 +184,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "09815b3d",
+   "id": "65eeb878",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:14.513302Z",
-     "iopub.status.busy": "2023-10-26T14:58:14.512946Z",
-     "iopub.status.idle": "2023-10-26T14:58:19.950174Z",
-     "shell.execute_reply": "2023-10-26T14:58:19.949350Z"
+     "iopub.execute_input": "2023-10-27T01:52:02.257621Z",
+     "iopub.status.busy": "2023-10-27T01:52:02.257328Z",
+     "iopub.status.idle": "2023-10-27T01:52:06.608166Z",
+     "shell.execute_reply": "2023-10-27T01:52:06.607311Z"
     },
     "id": "sVBOII5GP9cw",
     "papermill": {
-     "duration": 5.455096,
-     "end_time": "2023-10-26T14:58:19.952165",
+     "duration": 4.366895,
+     "end_time": "2023-10-27T01:52:06.609810",
      "exception": false,
-     "start_time": "2023-10-26T14:58:14.497069",
+     "start_time": "2023-10-27T01:52:02.242915",
      "status": "completed"
     },
     "tags": []
@@ -207,7 +207,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-8a98526b-108e-49a1-9c5f-9963aea84ef9\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-ac419fbd-c201-4355-8cee-4b3e34927c72\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -305,7 +305,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-8a98526b-108e-49a1-9c5f-9963aea84ef9')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ac419fbd-c201-4355-8cee-4b3e34927c72')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -357,12 +357,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-8a98526b-108e-49a1-9c5f-9963aea84ef9 button.colab-df-convert');\n",
+       "        document.querySelector('#df-ac419fbd-c201-4355-8cee-4b3e34927c72 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-8a98526b-108e-49a1-9c5f-9963aea84ef9');\n",
+       "        const element = document.querySelector('#df-ac419fbd-c201-4355-8cee-4b3e34927c72');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -459,14 +459,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8f994ee",
+   "id": "0875104f",
    "metadata": {
     "id": "9Cl_ZOxqaaai",
     "papermill": {
-     "duration": 0.015553,
-     "end_time": "2023-10-26T14:58:19.983337",
+     "duration": 0.01277,
+     "end_time": "2023-10-27T01:52:06.636727",
      "exception": false,
-     "start_time": "2023-10-26T14:58:19.967784",
+     "start_time": "2023-10-27T01:52:06.623957",
      "status": "completed"
     },
     "tags": []
@@ -486,20 +486,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f001eaae",
+   "id": "87cd5a63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:20.017428Z",
-     "iopub.status.busy": "2023-10-26T14:58:20.016903Z",
-     "iopub.status.idle": "2023-10-26T14:58:23.591988Z",
-     "shell.execute_reply": "2023-10-26T14:58:23.590957Z"
+     "iopub.execute_input": "2023-10-27T01:52:06.663336Z",
+     "iopub.status.busy": "2023-10-27T01:52:06.662780Z",
+     "iopub.status.idle": "2023-10-27T01:52:10.044010Z",
+     "shell.execute_reply": "2023-10-27T01:52:10.042839Z"
     },
     "id": "D4dkFpEVfDO1",
     "papermill": {
-     "duration": 3.594132,
-     "end_time": "2023-10-26T14:58:23.594223",
+     "duration": 3.396538,
+     "end_time": "2023-10-27T01:52:10.045653",
      "exception": false,
-     "start_time": "2023-10-26T14:58:20.000091",
+     "start_time": "2023-10-27T01:52:06.649115",
      "status": "completed"
     },
     "tags": []
@@ -516,7 +516,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-9dd8f556-3d10-4ef9-97e6-730a5c2b2a5b\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-16eae3b1-7897-41a0-a355-a60ed044f693\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -614,7 +614,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-9dd8f556-3d10-4ef9-97e6-730a5c2b2a5b')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-16eae3b1-7897-41a0-a355-a60ed044f693')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -666,12 +666,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-9dd8f556-3d10-4ef9-97e6-730a5c2b2a5b button.colab-df-convert');\n",
+       "        document.querySelector('#df-16eae3b1-7897-41a0-a355-a60ed044f693 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-9dd8f556-3d10-4ef9-97e6-730a5c2b2a5b');\n",
+       "        const element = document.querySelector('#df-16eae3b1-7897-41a0-a355-a60ed044f693');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -785,14 +785,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d723fe5",
+   "id": "14af4946",
    "metadata": {
     "id": "ojgbk_nMhbv0",
     "papermill": {
-     "duration": 0.017318,
-     "end_time": "2023-10-26T14:58:23.629247",
+     "duration": 0.014404,
+     "end_time": "2023-10-27T01:52:10.073386",
      "exception": false,
-     "start_time": "2023-10-26T14:58:23.611929",
+     "start_time": "2023-10-27T01:52:10.058982",
      "status": "completed"
     },
     "tags": []
@@ -806,20 +806,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0b910a93",
+   "id": "ec174583",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:23.661210Z",
-     "iopub.status.busy": "2023-10-26T14:58:23.660873Z",
-     "iopub.status.idle": "2023-10-26T14:58:24.277515Z",
-     "shell.execute_reply": "2023-10-26T14:58:24.276526Z"
+     "iopub.execute_input": "2023-10-27T01:52:10.100222Z",
+     "iopub.status.busy": "2023-10-27T01:52:10.099911Z",
+     "iopub.status.idle": "2023-10-27T01:52:10.918019Z",
+     "shell.execute_reply": "2023-10-27T01:52:10.916994Z"
     },
     "id": "mr-F6YXrWHOm",
     "papermill": {
-     "duration": 0.635244,
-     "end_time": "2023-10-26T14:58:24.279707",
+     "duration": 0.834288,
+     "end_time": "2023-10-27T01:52:10.920285",
      "exception": false,
-     "start_time": "2023-10-26T14:58:23.644463",
+     "start_time": "2023-10-27T01:52:10.085997",
      "status": "completed"
     },
     "tags": []
@@ -829,9 +829,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2023-10-26 14:58:23--  https://github.com/peak/s5cmd/releases/download/v2.0.0/s5cmd_2.0.0_Linux-64bit.tar.gz\n",
-      "Resolving github.com (github.com)... 192.30.255.112\n",
-      "Connecting to github.com (github.com)|192.30.255.112|:443... connected.\n",
+      "--2023-10-27 01:52:10--  https://github.com/peak/s5cmd/releases/download/v2.0.0/s5cmd_2.0.0_Linux-64bit.tar.gz\n",
+      "Resolving github.com (github.com)... 140.82.113.4\n",
+      "Connecting to github.com (github.com)|140.82.113.4|:443... connected.\n",
       "HTTP request sent, awaiting response... "
      ]
     },
@@ -840,10 +840,10 @@
      "output_type": "stream",
      "text": [
       "302 Found\n",
-      "Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231026T145823Z&X-Amz-Expires=300&X-Amz-Signature=8af40435aaaf086d5ecf2b51a6f779584884ac50634a2d6f8b939708698be252&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream [following]\n",
-      "--2023-10-26 14:58:23--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231026T145823Z&X-Amz-Expires=300&X-Amz-Signature=8af40435aaaf086d5ecf2b51a6f779584884ac50634a2d6f8b939708698be252&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream\n",
-      "Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.111.133, ...\n",
-      "Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.108.133|:443... connected.\n",
+      "Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231027T015210Z&X-Amz-Expires=300&X-Amz-Signature=bca2fc80c71a54d31a82056a6ef24cb52402822de665488524b3742f2c3d40d4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream [following]\n",
+      "--2023-10-27 01:52:10--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/73909333/2e177ae0-614f-48ba-92fd-04cf9bf41529?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231027T015210Z&X-Amz-Expires=300&X-Amz-Signature=bca2fc80c71a54d31a82056a6ef24cb52402822de665488524b3742f2c3d40d4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=73909333&response-content-disposition=attachment%3B%20filename%3Ds5cmd_2.0.0_Linux-64bit.tar.gz&response-content-type=application%2Foctet-stream\n",
+      "Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.109.133, 185.199.110.133, ...\n",
+      "Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.\n",
       "HTTP request sent, awaiting response... "
      ]
     },
@@ -856,10 +856,17 @@
       "Saving to: ‘s5cmd_2.0.0_Linux-64bit.tar.gz’\n",
       "\n",
       "\r",
-      "          s5cmd_2.0   0%[                    ]       0  --.-KB/s               \r",
-      "s5cmd_2.0.0_Linux-6 100%[===================>]   4.08M  --.-KB/s    in 0.02s   \n",
+      "          s5cmd_2.0   0%[                    ]       0  --.-KB/s               "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "s5cmd_2.0.0_Linux-6 100%[===================>]   4.08M  24.7MB/s    in 0.2s    \n",
       "\n",
-      "2023-10-26 14:58:24 (164 MB/s) - ‘s5cmd_2.0.0_Linux-64bit.tar.gz’ saved [4276789/4276789]\n",
+      "2023-10-27 01:52:10 (24.7 MB/s) - ‘s5cmd_2.0.0_Linux-64bit.tar.gz’ saved [4276789/4276789]\n",
       "\n"
      ]
     },
@@ -913,14 +920,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e13e701",
+   "id": "c5fc5d6b",
    "metadata": {
     "id": "gdrjpXYM--IH",
     "papermill": {
-     "duration": 0.017221,
-     "end_time": "2023-10-26T14:58:24.314274",
+     "duration": 0.013475,
+     "end_time": "2023-10-27T01:52:10.948089",
      "exception": false,
-     "start_time": "2023-10-26T14:58:24.297053",
+     "start_time": "2023-10-27T01:52:10.934614",
      "status": "completed"
     },
     "tags": []
@@ -932,20 +939,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "db4f2367",
+   "id": "36ab55ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:24.389010Z",
-     "iopub.status.busy": "2023-10-26T14:58:24.388576Z",
-     "iopub.status.idle": "2023-10-26T14:58:28.066321Z",
-     "shell.execute_reply": "2023-10-26T14:58:28.065464Z"
+     "iopub.execute_input": "2023-10-27T01:52:11.001609Z",
+     "iopub.status.busy": "2023-10-27T01:52:11.001263Z",
+     "iopub.status.idle": "2023-10-27T01:52:14.077606Z",
+     "shell.execute_reply": "2023-10-27T01:52:14.076675Z"
     },
     "id": "gZhsxNbuWXy7",
     "papermill": {
-     "duration": 3.737317,
-     "end_time": "2023-10-26T14:58:28.068664",
+     "duration": 3.118158,
+     "end_time": "2023-10-27T01:52:14.079516",
      "exception": false,
-     "start_time": "2023-10-26T14:58:24.331347",
+     "start_time": "2023-10-27T01:52:10.961358",
      "status": "completed"
     },
     "tags": []
@@ -1003,14 +1010,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce631830",
+   "id": "102eb516",
    "metadata": {
     "id": "M94EtV6jBnXg",
     "papermill": {
-     "duration": 0.019528,
-     "end_time": "2023-10-26T14:58:28.105436",
+     "duration": 0.014011,
+     "end_time": "2023-10-27T01:52:14.106030",
      "exception": false,
-     "start_time": "2023-10-26T14:58:28.085908",
+     "start_time": "2023-10-27T01:52:14.092019",
      "status": "completed"
     },
     "tags": []
@@ -1022,20 +1029,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "7c549bb8",
+   "id": "b0dc0a1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:28.140713Z",
-     "iopub.status.busy": "2023-10-26T14:58:28.140355Z",
-     "iopub.status.idle": "2023-10-26T14:58:29.475912Z",
-     "shell.execute_reply": "2023-10-26T14:58:29.474954Z"
+     "iopub.execute_input": "2023-10-27T01:52:14.133262Z",
+     "iopub.status.busy": "2023-10-27T01:52:14.132925Z",
+     "iopub.status.idle": "2023-10-27T01:52:15.260914Z",
+     "shell.execute_reply": "2023-10-27T01:52:15.259379Z"
     },
     "id": "DvFRdvyPWpAE",
     "papermill": {
-     "duration": 1.355781,
-     "end_time": "2023-10-26T14:58:29.478082",
+     "duration": 1.143863,
+     "end_time": "2023-10-27T01:52:15.262882",
      "exception": false,
-     "start_time": "2023-10-26T14:58:28.122301",
+     "start_time": "2023-10-27T01:52:14.119019",
      "status": "completed"
     },
     "tags": []
@@ -1045,168 +1052,156 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
-      "cp s3://public-datasets-idc/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
+      "cp s3://public-datasets-idc/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
+      "cp s3://public-datasets-idc/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
+      "cp s3://public-datasets-idc/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
+      "cp s3://public-datasets-idc/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
+      "cp s3://public-datasets-idc/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
+      "cp s3://public-datasets-idc/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
-      "cp s3://public-datasets-idc/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
-      "cp s3://public-datasets-idc/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
-      "cp s3://public-datasets-idc/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
-      "cp s3://public-datasets-idc/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
-      "cp s3://public-datasets-idc/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n"
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
+      "cp s3://idc-open-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
-      "cp s3://public-datasets-idc/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
-      "cp s3://public-datasets-idc/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
-      "cp s3://public-datasets-idc/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
-      "cp s3://idc-open-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
+      "cp s3://public-datasets-idc/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
+      "cp s3://public-datasets-idc/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
+      "cp s3://public-datasets-idc/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
       "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
-      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
+      "cp s3://idc-open-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
       "cp s3://idc-open-cr/acabf2ce-1b29-4ae9-87ec-528c196cb1c0/e2db7522-d068-427d-9e3a-e01c02beafb3.dcm e2db7522-d068-427d-9e3a-e01c02beafb3.dcm\n"
      ]
     }
@@ -1222,20 +1217,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c64187fe",
+   "id": "601f654a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:29.514313Z",
-     "iopub.status.busy": "2023-10-26T14:58:29.513962Z",
-     "iopub.status.idle": "2023-10-26T14:58:31.743219Z",
-     "shell.execute_reply": "2023-10-26T14:58:31.742219Z"
+     "iopub.execute_input": "2023-10-27T01:52:15.294195Z",
+     "iopub.status.busy": "2023-10-27T01:52:15.293911Z",
+     "iopub.status.idle": "2023-10-27T01:52:16.821350Z",
+     "shell.execute_reply": "2023-10-27T01:52:16.820630Z"
     },
     "id": "e6BjWfTTC5kS",
     "papermill": {
-     "duration": 2.25027,
-     "end_time": "2023-10-26T14:58:31.745704",
+     "duration": 1.546208,
+     "end_time": "2023-10-27T01:52:16.823619",
      "exception": false,
-     "start_time": "2023-10-26T14:58:29.495434",
+     "start_time": "2023-10-27T01:52:15.277411",
      "status": "completed"
     },
     "tags": []
@@ -1246,168 +1241,167 @@
      "output_type": "stream",
      "text": [
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm fc60af04-9d30-4ab2-9051-0be15b7957d2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm d09cd9a1-e9d1-4574-b751-4d28228b872f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/670268c3-864e-4699-a1fe-638d1dcc403b.dcm 670268c3-864e-4699-a1fe-638d1dcc403b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
-      "cp s3://idc-open-data/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e096febf-5402-415f-a4bb-63984a49ccf8.dcm e096febf-5402-415f-a4bb-63984a49ccf8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5b8c0158-af92-4531-949e-ad37da2d8964.dcm 5b8c0158-af92-4531-949e-ad37da2d8964.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm d72da73d-d6d8-4e4c-a7cf-9f3223438418.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
-      "cp s3://idc-open-data/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
-      "cp s3://idc-open-data/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
-      "cp s3://idc-open-data/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
-      "cp s3://idc-open-data/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm 8a3445cd-7be1-4cf4-9894-bf40c02d835e.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm d51a4201-cf31-47e8-ae1c-03e4b2c2847d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm c676aca4-74f3-4f78-b173-ccf7f90570d4.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm 9088069e-fb5b-43b1-b470-a7ddd3bd2b5d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c33169f0-5388-42ea-bdff-c810a7424358.dcm c33169f0-5388-42ea-bdff-c810a7424358.dcm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/001cf2a8-a794-4549-87d5-a227a04f19bb.dcm 001cf2a8-a794-4549-87d5-a227a04f19bb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm 4d7dfec7-b639-4ae1-84a9-8006d77a7eae.dcm\n",
+      "cp s3://idc-open-data/981246bc-c265-4551-b788-2874b43233cc/7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm 7e528619-6ff6-418c-bbb9-5ce87c83f72e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/409ba2b8-ea38-4c68-b566-e29f605882be.dcm 409ba2b8-ea38-4c68-b566-e29f605882be.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm 31cf05fa-ccdc-4610-93e4-f7f1559d1fb8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/322c04b3-8991-43ec-a2d5-08bada08c977.dcm 322c04b3-8991-43ec-a2d5-08bada08c977.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/667893a5-7b6a-4bf6-863d-a897fd712440.dcm 667893a5-7b6a-4bf6-863d-a897fd712440.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm 168b93ad-dc76-4a04-9ac6-4600d6c3ee94.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
-      "cp s3://idc-open-data/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
       "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm 8fcedc8d-98c6-4bbc-a2ab-d67cfb09bf68.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
-      "cp s3://idc-open-data-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
-      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n"
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm 55ff924a-3019-4e0b-9df6-476ab24aacb2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm 640df5d0-7013-46f5-a8c8-8a87e7f13d75.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b8163916-4d88-4220-a982-9c7ed0956319.dcm b8163916-4d88-4220-a982-9c7ed0956319.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e77ba000-f7d7-466c-96df-b0063e86238d.dcm e77ba000-f7d7-466c-96df-b0063e86238d.dcm\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm c5410d5a-1acb-44ba-b7bc-e38e6d10167a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm d43c5d7c-30d4-4b6a-b371-52355d4d0515.dcm\n",
+      "cp s3://idc-open-data/ffba01af-2e69-4a13-bf0f-a55dbd2bef03/918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm 918c957b-d06a-4b65-9b63-3c2c3f46b56a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm 075ac5f2-bfd3-4e80-89db-44e7f4817d4c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ea757637-a571-4cbf-bb95-53ef8910c347.dcm ea757637-a571-4cbf-bb95-53ef8910c347.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm 0407c371-d12c-4435-9f59-2a56f31cdf9c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm a8c7cbd5-c1e7-45d1-9661-ec21a122d1fc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm 0cc44bc8-20a6-42ac-ace9-bbce6792352d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm 5d50f47b-4286-4809-8f3b-a6ffce9d7f36.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5939ed66-a914-4a03-b471-94148d09f9a0.dcm 5939ed66-a914-4a03-b471-94148d09f9a0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm 9556523e-9c73-4ff7-9509-ba4a52037d6b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/55adeb68-90fa-41ca-8551-e489bc858003.dcm 55adeb68-90fa-41ca-8551-e489bc858003.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eddce88f-6bab-4311-9846-754f84bae051.dcm eddce88f-6bab-4311-9846-754f84bae051.dcm\n",
+      "cp s3://idc-open-data/1fbaf79a-2082-419e-8a47-8b4fd575b0ea/65fd379f-9219-4b09-a5c2-69d79f94b724.dcm 65fd379f-9219-4b09-a5c2-69d79f94b724.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm cfb7d09c-457a-4d36-8410-7dac98056e3d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2700db2b-e225-47df-80c5-d8c2c66e128e.dcm 2700db2b-e225-47df-80c5-d8c2c66e128e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm ce345c63-3c25-4db4-a4b2-13c4b71a95e9.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/161752d6-4dd3-490b-9925-29dcf7827c36.dcm 161752d6-4dd3-490b-9925-29dcf7827c36.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/901edd02-4d28-411a-b488-08079a3d51a7.dcm 901edd02-4d28-411a-b488-08079a3d51a7.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm 89b0a728-233b-4024-9ec9-d03bf337eb9e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm e8caff47-9382-4f46-8c2b-6ef09a06d016.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/77ed681b-db94-4a92-a08a-694e4acd891e.dcm 77ed681b-db94-4a92-a08a-694e4acd891e.dcm\n",
+      "cp s3://idc-open-data/7a695bb0-53c0-4dfc-8e9d-fb0ff123db31/4949bbe7-a2ba-42a2-a649-48433746cfec.dcm 4949bbe7-a2ba-42a2-a649-48433746cfec.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm 520e6a7a-5127-4d6e-b1bb-a3bd8b3bef61.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm ce8629d1-c838-4dea-88ba-365ed0e9dcd3.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm 392d81b5-a8d3-45bb-ac67-1f27accd9e3f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff355159-19da-4d26-82c0-0421d0df8ac0.dcm ff355159-19da-4d26-82c0-0421d0df8ac0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6114fa4f-ff52-4750-9e13-96267b8f5028.dcm 6114fa4f-ff52-4750-9e13-96267b8f5028.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm 17ce37bb-58e8-4e8b-8524-bd56d1be7a9b.dcm\n",
+      "cp s3://idc-open-data/17ef67ef-11de-412c-84e2-1a48284b7755/1af63bb9-09e1-4353-8518-f7952b7d7936.dcm 1af63bb9-09e1-4353-8518-f7952b7d7936.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm b2ec5aea-2b06-4575-84f5-61ac569d5edd.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b481868e-7bb9-43fe-affe-c27002ee6aee.dcm b481868e-7bb9-43fe-affe-c27002ee6aee.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm 2ec7dd38-6ddb-4fc3-9d40-35e329150fd5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/679e6c9a-b558-4727-90c8-efc88093c78a.dcm 679e6c9a-b558-4727-90c8-efc88093c78a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm 5caf0fa3-2955-4e8e-a01d-346958edfad9.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/82740a91-5e93-45db-9519-d1f98435a339.dcm 82740a91-5e93-45db-9519-d1f98435a339.dcm\n",
+      "cp s3://idc-open-data/c7086d91-6ac8-4ced-a8d4-0660e3d0043b/780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm 780e9ecc-8236-4b6b-9720-9e4216bcfd54.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm 65f499b1-15f7-46b2-8cf4-4e2b1d5db4f5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm 03096852-e1f2-4ab6-90ad-8b48dd8e8566.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/556fb504-a9e3-4eb5-9405-51668936fac4.dcm 556fb504-a9e3-4eb5-9405-51668936fac4.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c3d8c563-c828-4139-8430-487f983ec2f2.dcm c3d8c563-c828-4139-8430-487f983ec2f2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm 04dd80ec-f5f9-4ad6-b0f7-08de7977ffd6.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm 1bb3d088-8810-46ad-9464-3c36d9f3b9da.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/88820087-a611-446b-8846-eec5d36dd655.dcm 88820087-a611-446b-8846-eec5d36dd655.dcm\n",
+      "cp s3://idc-open-data/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm 4e4fe9d1-61eb-4cd6-8336-603aeddf943a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/48822b51-fe25-454c-967e-1026fefadcc1.dcm 48822b51-fe25-454c-967e-1026fefadcc1.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm 83576e6a-5d77-4528-bd8c-ec9613c4ec3a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm 2a9cf9ad-6737-41f0-97fd-269d4dee4d68.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm 9fef4f1b-ee6b-45ae-bd0c-df15275da508.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm b61c08a3-5337-42c6-8c79-e4baa35b9472.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm 2a0642d9-d12d-44cb-b9c2-0f4ace966ead.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm d979d6fb-39ba-4b20-9e94-6f9d34c2616f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm 3e7445b8-b3bf-4109-9ff0-ceab33ce04d0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm 837984fb-3a58-4ee2-90c8-b1c105a21a06.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm 12ad7832-12e9-4633-9f18-c74a218d2ac1.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm e0242876-6cdb-4b0c-8bd4-759cb14438a8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1307e541-3be3-4e48-bda9-6041188c1a5c.dcm 1307e541-3be3-4e48-bda9-6041188c1a5c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7a8b3644-29a7-4244-9f49-36b54751c048.dcm 7a8b3644-29a7-4244-9f49-36b54751c048.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm a62ff86e-7e3d-4788-98b8-80d902cc5c6b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1facfad2-48a8-4990-82a6-af3a436d42c5.dcm 1facfad2-48a8-4990-82a6-af3a436d42c5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm 5e2aec2c-914f-4379-b7d1-b73234eb3c13.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm 6f5f2a7e-76cb-42c3-932d-df808be8ee7c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm 7f974e9f-30c9-4fd3-9cdb-99c961032726.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/28fb3d25-234f-4cac-8792-3db75f4315cc.dcm 28fb3d25-234f-4cac-8792-3db75f4315cc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6c0a7399-fa58-4ade-bebd-777421febf98.dcm 6c0a7399-fa58-4ade-bebd-777421febf98.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm f89557c9-2da2-44c8-bb5e-c30f6121b0ed.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/330c39f5-c09b-46f3-8147-9e35277de6e7.dcm 330c39f5-c09b-46f3-8147-9e35277de6e7.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/557358a2-3e0c-494e-afc5-20bb462e221f.dcm 557358a2-3e0c-494e-afc5-20bb462e221f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm 509d4cb8-5b13-4fed-8306-c20bf0dc2ca8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm 4ba2b28f-b716-47aa-bf57-064a200cd56b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm 85b75be9-318b-48b6-8a56-81dcf77ed20c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9006baa5-8f13-4efe-9100-2ed79923c061.dcm 9006baa5-8f13-4efe-9100-2ed79923c061.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bee45122-b520-4a48-9609-26f0efbc2a47.dcm bee45122-b520-4a48-9609-26f0efbc2a47.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm 3b5be888-ba3b-4b29-8f1a-64de7d9490e1.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm 07c06c2b-bf99-4a25-bf38-0cf1bc3a5efb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/280345cb-0f22-4f57-a140-de25196bb648.dcm 280345cb-0f22-4f57-a140-de25196bb648.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm eaf84629-1ac0-419d-a7a4-98fcdeb83573.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm d0eae108-3d8e-4d12-aa23-183a5470dcf8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm ad654760-48f9-4f53-bb8d-e8ccc6e3e09b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c70043ff-1f01-4a72-bfa1-f051638c2648.dcm c70043ff-1f01-4a72-bfa1-f051638c2648.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2fa67315-9144-42e7-bc8a-78632d491f96.dcm 2fa67315-9144-42e7-bc8a-78632d491f96.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm 2e9bb6f5-5194-4f16-9417-5ed7a4a66370.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm 3b5c7637-e08e-4048-bc2d-7e3f763f3aaf.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm 52b2bca6-9155-48a7-91c3-6b960ddd9b3e.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm 067408dc-61e7-4dce-8639-5c8a1dcb3f75.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/bbb21e72-a458-4e40-9bac-8723188592bc.dcm bbb21e72-a458-4e40-9bac-8723188592bc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm 1297ef07-02ad-4160-bf54-2b433ef5a73b.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm d19b5a0f-4980-4cc5-9736-2d3744c901be.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm 876c9d2f-73d5-42b4-bf25-cee5986cee38.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm 7294049b-965f-4f1b-b133-6cb12b9e48c6.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d7200a0d-d56e-46a2-85a4-f80924096152.dcm d7200a0d-d56e-46a2-85a4-f80924096152.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f9915fce-c366-44bb-bc61-680b7e45de08.dcm f9915fce-c366-44bb-bc61-680b7e45de08.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/c1d60967-f527-4975-9d47-21363b7def21.dcm c1d60967-f527-4975-9d47-21363b7def21.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm d878d158-c4fb-4566-84c9-5c68af94e1ca.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm 7ed1859a-37f5-4b76-89d4-7dc52ce8eadc.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/38425b8f-8312-4cdf-83e6-88edc172fed2.dcm 38425b8f-8312-4cdf-83e6-88edc172fed2.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm ff9194e3-ee51-4c89-8399-ff27f62ed4b8.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm a88c8f96-b32d-4f03-8ad9-9001f0e588e9.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/2c914507-2019-48df-976a-81bcb3919850.dcm 2c914507-2019-48df-976a-81bcb3919850.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d889e21a-d718-4892-8d95-008205210796.dcm d889e21a-d718-4892-8d95-008205210796.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/a216e589-3ae1-4414-8773-bc501d723eeb.dcm a216e589-3ae1-4414-8773-bc501d723eeb.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/9ef03b73-43dd-485b-9c95-22d8d5226101.dcm 9ef03b73-43dd-485b-9c95-22d8d5226101.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm 03d2f867-f09e-4a0c-9a76-96a9a97f96fa.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm 4d7fe6e4-8254-41ef-9bd8-93dba18164bf.dcm\n",
+      "cp s3://idc-open-data-cr/396aeb43-057b-4b30-a3ae-0109980aae4b/d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm d986a6ea-34b5-4eb6-8350-7a5cf1ea30a0.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm 3d59b99c-4e48-4447-9564-4dbd3ec4edf5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm 512dd0ca-ceea-464f-bf4e-aa469ea6251d.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm 6e6b0ebb-823a-4ba1-9672-ac24779c1562.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d8da9e84-06a0-4a02-998b-2a128542da63.dcm d8da9e84-06a0-4a02-998b-2a128542da63.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm d4b20d84-ec6c-40ce-8b55-d9af5dc5120a.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/4acba928-0f09-4b6a-9ffc-21e798df829f.dcm 4acba928-0f09-4b6a-9ffc-21e798df829f.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm 74b0399f-f156-4227-bdc9-36e1f6f2fcc5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm f56f16ba-e20b-403a-9087-6602e1fae4b5.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm 706ad718-f19d-4c1f-bcc7-7ddfbf4df3c2.dcm\n",
       "cp s3://idc-open-data/9a62139f-a8c5-4c7e-b528-e34220a4b2bc/0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm 0dcfaf13-5177-48f5-85a6-652fae0108f8.dcm\n",
-      "cp s3://idc-open-data/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n",
-      "cp s3://idc-open-data/d1b9d6cf-2299-44fe-94dc-9d217237068e/0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm 0c30b6ee-8e56-470f-bd90-e47ef4fca1bb.dcm\n"
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm 890245d8-ab4f-49fa-8064-5c2627c9d91a.dcm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm b87f920c-0fb0-43d7-9406-79cb6100e31c.dcm\n",
+      "cp s3://idc-open-data-cr/d3575c66-e7f8-4558-b63b-16689fa6f519/98ef5b47-4ad2-454b-b522-410a89d0112f.dcm 98ef5b47-4ad2-454b-b522-410a89d0112f.dcm\n",
+      "cp s3://idc-open-data/43c7ff98-9ccb-4667-9dbe-d0a6c984b5d8/7ca528b6-7eb3-44b2-824d-5bf445821535.dcm 7ca528b6-7eb3-44b2-824d-5bf445821535.dcm\n"
      ]
     },
     {
@@ -1428,14 +1422,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83b4d044",
+   "id": "87cfddc6",
    "metadata": {
     "id": "7LjNNakzVKvV",
     "papermill": {
-     "duration": 0.018028,
-     "end_time": "2023-10-26T14:58:31.782917",
+     "duration": 0.0189,
+     "end_time": "2023-10-27T01:52:16.857239",
      "exception": false,
-     "start_time": "2023-10-26T14:58:31.764889",
+     "start_time": "2023-10-27T01:52:16.838339",
      "status": "completed"
     },
     "tags": []
@@ -1456,25 +1450,25 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "04016646",
+   "id": "ff4baf1b",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 206
     },
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:31.826477Z",
-     "iopub.status.busy": "2023-10-26T14:58:31.825961Z",
-     "iopub.status.idle": "2023-10-26T14:58:35.420679Z",
-     "shell.execute_reply": "2023-10-26T14:58:35.419752Z"
+     "iopub.execute_input": "2023-10-27T01:52:16.886428Z",
+     "iopub.status.busy": "2023-10-27T01:52:16.886115Z",
+     "iopub.status.idle": "2023-10-27T01:52:20.468186Z",
+     "shell.execute_reply": "2023-10-27T01:52:20.467249Z"
     },
     "id": "bW5ULTmfpa7g",
     "outputId": "536ed0ec-1816-4604-e1bc-7cb221c5015f",
     "papermill": {
-     "duration": 3.619073,
-     "end_time": "2023-10-26T14:58:35.422906",
+     "duration": 3.598813,
+     "end_time": "2023-10-27T01:52:20.470397",
      "exception": false,
-     "start_time": "2023-10-26T14:58:31.803833",
+     "start_time": "2023-10-27T01:52:16.871584",
      "status": "completed"
     },
     "tags": []
@@ -1484,7 +1478,7 @@
      "data": {
       "text/html": [
        "\n",
-       "  <div id=\"df-40cdd759-938a-4b8e-85df-ce374cb537f5\" class=\"colab-df-container\">\n",
+       "  <div id=\"df-036e75a2-7744-42ad-91e9-1956b40c1303\" class=\"colab-df-container\">\n",
        "    <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1572,7 +1566,7 @@
        "    <div class=\"colab-df-buttons\">\n",
        "      \n",
        "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-40cdd759-938a-4b8e-85df-ce374cb537f5')\"\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-036e75a2-7744-42ad-91e9-1956b40c1303')\"\n",
        "            title=\"Convert this dataframe to an interactive table.\"\n",
        "            style=\"display:none;\">\n",
        "      \n",
@@ -1624,12 +1618,12 @@
        "\n",
        "    <script>\n",
        "      const buttonEl =\n",
-       "        document.querySelector('#df-40cdd759-938a-4b8e-85df-ce374cb537f5 button.colab-df-convert');\n",
+       "        document.querySelector('#df-036e75a2-7744-42ad-91e9-1956b40c1303 button.colab-df-convert');\n",
        "      buttonEl.style.display =\n",
        "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
        "\n",
        "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-40cdd759-938a-4b8e-85df-ce374cb537f5');\n",
+       "        const element = document.querySelector('#df-036e75a2-7744-42ad-91e9-1956b40c1303');\n",
        "        const dataTable =\n",
        "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
        "                                                    [key], {});\n",
@@ -1746,14 +1740,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9580540",
+   "id": "b2dbc1c1",
    "metadata": {
     "id": "JkUqWsLVprGU",
     "papermill": {
-     "duration": 0.017878,
-     "end_time": "2023-10-26T14:58:35.458727",
+     "duration": 0.014805,
+     "end_time": "2023-10-27T01:52:20.501810",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.440849",
+     "start_time": "2023-10-27T01:52:20.487005",
      "status": "completed"
     },
     "tags": []
@@ -1765,20 +1759,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "69cf1a43",
+   "id": "412631de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:35.495145Z",
-     "iopub.status.busy": "2023-10-26T14:58:35.494790Z",
-     "iopub.status.idle": "2023-10-26T14:58:35.501265Z",
-     "shell.execute_reply": "2023-10-26T14:58:35.500300Z"
+     "iopub.execute_input": "2023-10-27T01:52:20.532042Z",
+     "iopub.status.busy": "2023-10-27T01:52:20.531716Z",
+     "iopub.status.idle": "2023-10-27T01:52:20.537273Z",
+     "shell.execute_reply": "2023-10-27T01:52:20.536517Z"
     },
     "id": "rmEGwPyUqrYr",
     "papermill": {
-     "duration": 0.027145,
-     "end_time": "2023-10-26T14:58:35.503239",
+     "duration": 0.023471,
+     "end_time": "2023-10-27T01:52:20.539221",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.476094",
+     "start_time": "2023-10-27T01:52:20.515750",
      "status": "completed"
     },
     "tags": []
@@ -1809,14 +1803,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a35e260",
+   "id": "854eaf2b",
    "metadata": {
     "id": "_tlbgnncq92y",
     "papermill": {
-     "duration": 0.017718,
-     "end_time": "2023-10-26T14:58:35.538555",
+     "duration": 0.014225,
+     "end_time": "2023-10-27T01:52:20.568581",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.520837",
+     "start_time": "2023-10-27T01:52:20.554356",
      "status": "completed"
     },
     "tags": []
@@ -1831,14 +1825,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3508c8a7",
+   "id": "563036c8",
    "metadata": {
     "id": "ZmL8qyT6StGt",
     "papermill": {
-     "duration": 0.024156,
-     "end_time": "2023-10-26T14:58:35.585589",
+     "duration": 0.013679,
+     "end_time": "2023-10-27T01:52:20.595884",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.561433",
+     "start_time": "2023-10-27T01:52:20.582205",
      "status": "completed"
     },
     "tags": []
@@ -1851,14 +1845,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ef02a28",
+   "id": "93cd6441",
    "metadata": {
     "id": "sf8Iu3ZPJAmX",
     "papermill": {
-     "duration": 0.018198,
-     "end_time": "2023-10-26T14:58:35.623553",
+     "duration": 0.014682,
+     "end_time": "2023-10-27T01:52:20.625905",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.605355",
+     "start_time": "2023-10-27T01:52:20.611223",
      "status": "completed"
     },
     "tags": []
@@ -1874,24 +1868,24 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b08eea63",
+   "id": "a56d5af5",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:35.670288Z",
-     "iopub.status.busy": "2023-10-26T14:58:35.669939Z",
-     "iopub.status.idle": "2023-10-26T14:58:35.674249Z",
-     "shell.execute_reply": "2023-10-26T14:58:35.673580Z"
+     "iopub.execute_input": "2023-10-27T01:52:20.657672Z",
+     "iopub.status.busy": "2023-10-27T01:52:20.657156Z",
+     "iopub.status.idle": "2023-10-27T01:52:20.663590Z",
+     "shell.execute_reply": "2023-10-27T01:52:20.662768Z"
     },
     "id": "JVIqa3GWUV64",
     "outputId": "85d71354-1c2e-4ae9-8c7a-90828c7b72cb",
     "papermill": {
-     "duration": 0.026555,
-     "end_time": "2023-10-26T14:58:35.676032",
+     "duration": 0.024489,
+     "end_time": "2023-10-27T01:52:20.665164",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.649477",
+     "start_time": "2023-10-27T01:52:20.640675",
      "status": "completed"
     },
     "tags": []
@@ -1914,14 +1908,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b6eac22",
+   "id": "49e43368",
    "metadata": {
     "id": "AkDL5e6bqSEa",
     "papermill": {
-     "duration": 0.01772,
-     "end_time": "2023-10-26T14:58:35.711766",
+     "duration": 0.017369,
+     "end_time": "2023-10-27T01:52:20.696769",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.694046",
+     "start_time": "2023-10-27T01:52:20.679400",
      "status": "completed"
     },
     "tags": []
@@ -1944,7 +1938,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "df90c069",
+   "id": "a0e00604",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1975,18 +1969,18 @@
      ]
     },
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:35.748258Z",
-     "iopub.status.busy": "2023-10-26T14:58:35.747926Z",
-     "iopub.status.idle": "2023-10-26T14:58:41.034638Z",
-     "shell.execute_reply": "2023-10-26T14:58:41.033720Z"
+     "iopub.execute_input": "2023-10-27T01:52:20.729250Z",
+     "iopub.status.busy": "2023-10-27T01:52:20.728930Z",
+     "iopub.status.idle": "2023-10-27T01:52:25.460714Z",
+     "shell.execute_reply": "2023-10-27T01:52:25.459878Z"
     },
     "id": "_gKhp0yruoIQ",
     "outputId": "f08bc23d-8c29-4284-e6a9-d4ddb1103616",
     "papermill": {
-     "duration": 5.30784,
-     "end_time": "2023-10-26T14:58:41.037071",
+     "duration": 4.749803,
+     "end_time": "2023-10-27T01:52:25.462491",
      "exception": false,
-     "start_time": "2023-10-26T14:58:35.729231",
+     "start_time": "2023-10-27T01:52:20.712688",
      "status": "completed"
     },
     "tags": []
@@ -1995,7 +1989,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f9e382a5fc084d528800641362693cea",
+       "model_id": "f7da54fe6529416c84eebc19eca68375",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2009,7 +2003,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4b5176c49b1a4cb6a0bc2b0f95303d4a",
+       "model_id": "a561963e86f84c008f62d3a39e32f00a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2039,24 +2033,24 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "91eb475e",
+   "id": "3c0b364a",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:41.076363Z",
-     "iopub.status.busy": "2023-10-26T14:58:41.075803Z",
-     "iopub.status.idle": "2023-10-26T14:58:41.081584Z",
-     "shell.execute_reply": "2023-10-26T14:58:41.080397Z"
+     "iopub.execute_input": "2023-10-27T01:52:25.496593Z",
+     "iopub.status.busy": "2023-10-27T01:52:25.496306Z",
+     "iopub.status.idle": "2023-10-27T01:52:25.501031Z",
+     "shell.execute_reply": "2023-10-27T01:52:25.500254Z"
     },
     "id": "eXITO1mauy7x",
     "outputId": "ffdb16cd-5f00-4514-8d86-6d2450590cca",
     "papermill": {
-     "duration": 0.027631,
-     "end_time": "2023-10-26T14:58:41.083419",
+     "duration": 0.023194,
+     "end_time": "2023-10-27T01:52:25.502724",
      "exception": false,
-     "start_time": "2023-10-26T14:58:41.055788",
+     "start_time": "2023-10-27T01:52:25.479530",
      "status": "completed"
     },
     "tags": []
@@ -2066,11 +2060,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://volview.kitware.app/?urls=s3://idc-open-data/b20fe53c-aaf4-438b-980a-a5e3162f322d\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/89234f83-ee62-4ce8-bc75-b78f8fee9468\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/d7ec3af4-d8b0-45ca-ba85-143b64c9bbe9\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/97b493ec-771c-42c7-93c9-0676501634b4\n",
-      "https://volview.kitware.app/?urls=s3://idc-open-data/a7b7410a-02ce-4060-a7b2-de2375bdcffc\n"
+      "https://volview.kitware.app/?urls=s3://idc-open-data/2547454a-449e-4032-9b07-557700810d32\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/1f0a6f79-18e5-4971-918a-fcc65d5d013d\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/8df03fe8-e6a9-40db-a4bf-5105399675db\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/58165473-4391-4291-a6e8-759570d29efc\n",
+      "https://volview.kitware.app/?urls=s3://idc-open-data/b1ed1cc3-26d6-465a-a1da-a218421d3a55\n"
      ]
     }
    ],
@@ -2081,14 +2075,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d840f26c",
+   "id": "1ae91868",
    "metadata": {
     "id": "SSNXGczneqMw",
     "papermill": {
-     "duration": 0.0182,
-     "end_time": "2023-10-26T14:58:41.120266",
+     "duration": 0.01636,
+     "end_time": "2023-10-27T01:52:25.535402",
      "exception": false,
-     "start_time": "2023-10-26T14:58:41.102066",
+     "start_time": "2023-10-27T01:52:25.519042",
      "status": "completed"
     },
     "tags": []
@@ -2103,14 +2097,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c03dda3",
+   "id": "31f74c62",
    "metadata": {
     "id": "-zRHvX1ZK-Dn",
     "papermill": {
-     "duration": 0.018052,
-     "end_time": "2023-10-26T14:58:41.156649",
+     "duration": 0.015908,
+     "end_time": "2023-10-27T01:52:25.568147",
      "exception": false,
-     "start_time": "2023-10-26T14:58:41.138597",
+     "start_time": "2023-10-27T01:52:25.552239",
      "status": "completed"
     },
     "tags": []
@@ -2123,14 +2117,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a6a5e99",
+   "id": "49d5ff2b",
    "metadata": {
     "id": "pvcX4ZhS-OEu",
     "papermill": {
-     "duration": 0.018073,
-     "end_time": "2023-10-26T14:58:41.192960",
+     "duration": 0.015575,
+     "end_time": "2023-10-27T01:52:25.599173",
      "exception": false,
-     "start_time": "2023-10-26T14:58:41.174887",
+     "start_time": "2023-10-27T01:52:25.583598",
      "status": "completed"
     },
     "tags": []
@@ -2144,20 +2138,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "156af3cc",
+   "id": "414b9b62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:41.231153Z",
-     "iopub.status.busy": "2023-10-26T14:58:41.230622Z",
-     "iopub.status.idle": "2023-10-26T14:58:41.944121Z",
-     "shell.execute_reply": "2023-10-26T14:58:41.943100Z"
+     "iopub.execute_input": "2023-10-27T01:52:25.633154Z",
+     "iopub.status.busy": "2023-10-27T01:52:25.632822Z",
+     "iopub.status.idle": "2023-10-27T01:52:26.147499Z",
+     "shell.execute_reply": "2023-10-27T01:52:26.146571Z"
     },
     "id": "Bx9snM-MK-v9",
     "papermill": {
-     "duration": 0.735584,
-     "end_time": "2023-10-26T14:58:41.946538",
+     "duration": 0.534993,
+     "end_time": "2023-10-27T01:52:26.149566",
      "exception": false,
-     "start_time": "2023-10-26T14:58:41.210954",
+     "start_time": "2023-10-27T01:52:25.614573",
      "status": "completed"
     },
     "tags": []
@@ -2331,9 +2325,9 @@
       "Receiving objects:  81% (137/169)\r",
       "Receiving objects:  82% (139/169)\r",
       "Receiving objects:  83% (141/169)\r",
-      "remote: Total 169 (delta 23), reused 33 (delta 16), pack-reused 126\u001b[K\n",
       "Receiving objects:  84% (142/169)\r",
       "Receiving objects:  85% (144/169)\r",
+      "remote: Total 169 (delta 23), reused 33 (delta 16), pack-reused 126\u001b[K\n",
       "Receiving objects:  86% (146/169)\r",
       "Receiving objects:  87% (148/169)\r",
       "Receiving objects:  88% (149/169)\r",
@@ -2349,7 +2343,7 @@
       "Receiving objects:  98% (166/169)\r",
       "Receiving objects:  99% (168/169)\r",
       "Receiving objects: 100% (169/169)\r",
-      "Receiving objects: 100% (169/169), 87.84 KiB | 2.31 MiB/s, done.\n",
+      "Receiving objects: 100% (169/169), 87.84 KiB | 2.58 MiB/s, done.\n",
       "Resolving deltas:   0% (0/86)\r",
       "Resolving deltas:   1% (1/86)\r",
       "Resolving deltas:   2% (2/86)\r",
@@ -2450,20 +2444,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "38a60e7c",
+   "id": "6c498d34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:41.987060Z",
-     "iopub.status.busy": "2023-10-26T14:58:41.986577Z",
-     "iopub.status.idle": "2023-10-26T14:58:48.422017Z",
-     "shell.execute_reply": "2023-10-26T14:58:48.421204Z"
+     "iopub.execute_input": "2023-10-27T01:52:26.188792Z",
+     "iopub.status.busy": "2023-10-27T01:52:26.188385Z",
+     "iopub.status.idle": "2023-10-27T01:52:32.322767Z",
+     "shell.execute_reply": "2023-10-27T01:52:32.321885Z"
     },
     "id": "o9hS4wamM3jO",
     "papermill": {
-     "duration": 6.459049,
-     "end_time": "2023-10-26T14:58:48.424806",
+     "duration": 6.156665,
+     "end_time": "2023-10-27T01:52:32.324618",
      "exception": false,
-     "start_time": "2023-10-26T14:58:41.965757",
+     "start_time": "2023-10-27T01:52:26.167953",
      "status": "completed"
     },
     "tags": []
@@ -2474,9 +2468,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.1/1.8 MB\u001b[0m \u001b[31m2.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.1/1.8 MB\u001b[0m \u001b[31m15.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m20.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.1/1.8 MB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.6/1.8 MB\u001b[0m \u001b[31m9.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/1.8 MB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m \u001b[32m1.7/1.8 MB\u001b[0m \u001b[31m12.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m11.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     }
@@ -2487,14 +2483,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be3e9561",
+   "id": "f4e0e161",
    "metadata": {
     "id": "8I7d2S5tpP19",
     "papermill": {
-     "duration": 0.025931,
-     "end_time": "2023-10-26T14:58:48.472505",
+     "duration": 0.01613,
+     "end_time": "2023-10-27T01:52:32.358241",
      "exception": false,
-     "start_time": "2023-10-26T14:58:48.446574",
+     "start_time": "2023-10-27T01:52:32.342111",
      "status": "completed"
     },
     "tags": []
@@ -2506,20 +2502,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8dfb9b81",
+   "id": "2b3abde4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:48.519467Z",
-     "iopub.status.busy": "2023-10-26T14:58:48.519040Z",
-     "iopub.status.idle": "2023-10-26T14:58:50.744629Z",
-     "shell.execute_reply": "2023-10-26T14:58:50.743411Z"
+     "iopub.execute_input": "2023-10-27T01:52:32.392512Z",
+     "iopub.status.busy": "2023-10-27T01:52:32.392054Z",
+     "iopub.status.idle": "2023-10-27T01:52:34.820781Z",
+     "shell.execute_reply": "2023-10-27T01:52:34.819998Z"
     },
     "id": "QEPR3kszK_o-",
     "papermill": {
-     "duration": 2.253537,
-     "end_time": "2023-10-26T14:58:50.747661",
+     "duration": 2.448235,
+     "end_time": "2023-10-27T01:52:34.822547",
      "exception": false,
-     "start_time": "2023-10-26T14:58:48.494124",
+     "start_time": "2023-10-27T01:52:32.374312",
      "status": "completed"
     },
     "tags": []
@@ -2531,7 +2527,7 @@
      "text": [
       "\r",
       "  0% 0/145 [00:00<?, ?it/s]\r",
-      "  9% 13/145 [00:00<00:01, 129.36it/s]"
+      "  8% 12/145 [00:00<00:01, 118.21it/s]"
      ]
     },
     {
@@ -2539,7 +2535,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 37% 53/145 [00:00<00:00, 170.10it/s]"
+      " 37% 53/145 [00:00<00:00, 147.49it/s]"
      ]
     },
     {
@@ -2547,7 +2543,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 59% 86/145 [00:00<00:00, 95.17it/s] "
+      " 59% 86/145 [00:00<00:00, 83.19it/s] "
      ]
     },
     {
@@ -2555,8 +2551,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 68% 98/145 [00:01<00:00, 72.50it/s]\r",
-      " 82% 119/145 [00:01<00:00, 83.50it/s]"
+      " 67% 97/145 [00:01<00:00, 62.55it/s]"
      ]
     },
     {
@@ -2564,7 +2559,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 89% 129/145 [00:01<00:00, 77.37it/s]"
+      " 82% 119/145 [00:01<00:00, 74.50it/s]"
      ]
     },
     {
@@ -2572,8 +2567,9 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 95% 138/145 [00:01<00:00, 71.30it/s]\r",
-      "100% 145/145 [00:01<00:00, 86.78it/s]\n",
+      " 88% 128/145 [00:01<00:00, 68.06it/s]\r",
+      " 94% 136/145 [00:01<00:00, 62.84it/s]\r",
+      "100% 145/145 [00:01<00:00, 77.41it/s]\n",
       "Files sorted\n"
      ]
     }
@@ -2586,14 +2582,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9453514e",
+   "id": "a2a14a48",
    "metadata": {
     "id": "3iJRergFLgaf",
     "papermill": {
-     "duration": 0.018266,
-     "end_time": "2023-10-26T14:58:50.785258",
+     "duration": 0.017305,
+     "end_time": "2023-10-27T01:52:34.856491",
      "exception": false,
-     "start_time": "2023-10-26T14:58:50.766992",
+     "start_time": "2023-10-27T01:52:34.839186",
      "status": "completed"
     },
     "tags": []
@@ -2605,20 +2601,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "de05de81",
+   "id": "f615ae59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:58:50.823969Z",
-     "iopub.status.busy": "2023-10-26T14:58:50.823521Z",
-     "iopub.status.idle": "2023-10-26T14:59:32.263433Z",
-     "shell.execute_reply": "2023-10-26T14:59:32.262316Z"
+     "iopub.execute_input": "2023-10-27T01:52:34.890136Z",
+     "iopub.status.busy": "2023-10-27T01:52:34.889858Z",
+     "iopub.status.idle": "2023-10-27T01:53:21.943159Z",
+     "shell.execute_reply": "2023-10-27T01:53:21.942064Z"
     },
     "id": "Db18CEtoK_Md",
     "papermill": {
-     "duration": 41.461694,
-     "end_time": "2023-10-26T14:59:32.265365",
+     "duration": 47.073965,
+     "end_time": "2023-10-27T01:53:21.945785",
      "exception": false,
-     "start_time": "2023-10-26T14:58:50.803671",
+     "start_time": "2023-10-27T01:52:34.871820",
      "status": "completed"
     },
     "tags": []
@@ -2629,12 +2625,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/25.6 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.1/25.6 MB\u001b[0m \u001b[31m3.4 MB/s\u001b[0m eta \u001b[36m0:00:08\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.1/25.6 MB\u001b[0m \u001b[31m68.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.1/25.6 MB\u001b[0m \u001b[31m160.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.7/25.6 MB\u001b[0m \u001b[31m154.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m21.1/25.6 MB\u001b[0m \u001b[31m133.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.2/25.6 MB\u001b[0m \u001b[31m7.4 MB/s\u001b[0m eta \u001b[36m0:00:04\u001b[0m\r",
+      "\u001b[2K     \u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.6/25.6 MB\u001b[0m \u001b[31m8.4 MB/s\u001b[0m eta \u001b[36m0:00:03\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/25.6 MB\u001b[0m \u001b[31m9.9 MB/s\u001b[0m eta \u001b[36m0:00:03\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.5/25.6 MB\u001b[0m \u001b[31m11.0 MB/s\u001b[0m eta \u001b[36m0:00:03\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.1/25.6 MB\u001b[0m \u001b[31m12.0 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m"
      ]
     },
     {
@@ -2642,11 +2637,12 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.8/25.6 MB\u001b[0m \u001b[31m13.2 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.6/25.6 MB\u001b[0m \u001b[31m14.7 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/25.6 MB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/25.6 MB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/25.6 MB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.8/25.6 MB\u001b[0m \u001b[31m12.4 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m"
      ]
     },
     {
@@ -2654,12 +2650,14 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.9/25.6 MB\u001b[0m \u001b[31m13.9 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.2/25.6 MB\u001b[0m \u001b[31m15.7 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.6/25.6 MB\u001b[0m \u001b[31m17.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.5/25.6 MB\u001b[0m \u001b[31m20.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.5/25.6 MB\u001b[0m \u001b[31m24.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.2/25.6 MB\u001b[0m \u001b[31m23.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.6/25.6 MB\u001b[0m \u001b[31m24.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.9/25.6 MB\u001b[0m \u001b[31m36.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2667,20 +2665,12 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m185.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.6/25.6 MB\u001b[0m \u001b[31m14.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m17.9/25.6 MB\u001b[0m \u001b[31m43.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m21.1/25.6 MB\u001b[0m \u001b[31m51.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.3/25.6 MB\u001b[0m \u001b[31m97.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m97.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m25.5/25.6 MB\u001b[0m \u001b[31m97.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.6/25.6 MB\u001b[0m \u001b[31m56.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2689,10 +2679,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/52.6 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.4/52.6 MB\u001b[0m \u001b[31m163.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.2/52.6 MB\u001b[0m \u001b[31m161.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.7/52.6 MB\u001b[0m \u001b[31m160.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m21.9/52.6 MB\u001b[0m \u001b[31m154.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/52.6 MB\u001b[0m \u001b[31m133.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/52.6 MB\u001b[0m \u001b[31m93.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.3/52.6 MB\u001b[0m \u001b[31m62.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2700,11 +2689,15 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m27.2/52.6 MB\u001b[0m \u001b[31m152.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m32.3/52.6 MB\u001b[0m \u001b[31m150.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m38.5/52.6 MB\u001b[0m \u001b[31m164.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m44.0/52.6 MB\u001b[0m \u001b[31m168.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━\u001b[0m \u001b[32m48.6/52.6 MB\u001b[0m \u001b[31m141.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.4/52.6 MB\u001b[0m \u001b[31m61.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.5/52.6 MB\u001b[0m \u001b[31m61.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m13.2/52.6 MB\u001b[0m \u001b[31m54.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m15.7/52.6 MB\u001b[0m \u001b[31m67.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m19.2/52.6 MB\u001b[0m \u001b[31m83.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m22.0/52.6 MB\u001b[0m \u001b[31m90.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m23.1/52.6 MB\u001b[0m \u001b[31m72.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.4/52.6 MB\u001b[0m \u001b[31m70.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m29.3/52.6 MB\u001b[0m \u001b[31m71.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2712,11 +2705,14 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m145.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m145.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m145.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m145.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m145.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m29.4/52.6 MB\u001b[0m \u001b[31m70.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m30.4/52.6 MB\u001b[0m \u001b[31m53.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━\u001b[0m \u001b[32m34.6/52.6 MB\u001b[0m \u001b[31m69.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m37.5/52.6 MB\u001b[0m \u001b[31m65.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m38.8/52.6 MB\u001b[0m \u001b[31m65.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m38.8/52.6 MB\u001b[0m \u001b[31m65.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━\u001b[0m \u001b[32m40.6/52.6 MB\u001b[0m \u001b[31m58.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m44.0/52.6 MB\u001b[0m \u001b[31m58.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2724,10 +2720,62 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m145.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m30.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 kB\u001b[0m \u001b[31m12.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━\u001b[0m \u001b[32m47.1/52.6 MB\u001b[0m \u001b[31m56.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m50.5/52.6 MB\u001b[0m \u001b[31m93.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m96.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m52.6/52.6 MB\u001b[0m \u001b[31m10.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 kB\u001b[0m \u001b[31m16.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2736,13 +2784,12 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/81.2 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.2/81.2 MB\u001b[0m \u001b[31m157.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.7/81.2 MB\u001b[0m \u001b[31m155.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m15.7/81.2 MB\u001b[0m \u001b[31m150.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m20.7/81.2 MB\u001b[0m \u001b[31m137.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.7/81.2 MB\u001b[0m \u001b[31m137.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m31.0/81.2 MB\u001b[0m \u001b[31m148.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m36.5/81.2 MB\u001b[0m \u001b[31m156.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/81.2 MB\u001b[0m \u001b[31m141.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.0/81.2 MB\u001b[0m \u001b[31m88.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.6/81.2 MB\u001b[0m \u001b[31m83.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.6/81.2 MB\u001b[0m \u001b[31m83.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m17.2/81.2 MB\u001b[0m \u001b[31m113.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m21.8/81.2 MB\u001b[0m \u001b[31m127.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2750,13 +2797,11 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m43.0/81.2 MB\u001b[0m \u001b[31m182.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m49.5/81.2 MB\u001b[0m \u001b[31m181.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m55.6/81.2 MB\u001b[0m \u001b[31m177.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━\u001b[0m \u001b[32m62.0/81.2 MB\u001b[0m \u001b[31m174.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m68.4/81.2 MB\u001b[0m \u001b[31m182.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━\u001b[0m \u001b[32m74.3/81.2 MB\u001b[0m \u001b[31m171.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m77.8/81.2 MB\u001b[0m \u001b[31m131.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.2/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.2/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m25.2/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m26.1/81.2 MB\u001b[0m \u001b[31m54.8 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m28.6/81.2 MB\u001b[0m \u001b[31m51.0 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m"
      ]
     },
     {
@@ -2764,11 +2809,15 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m30.5/81.2 MB\u001b[0m \u001b[31m46.2 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m33.5/81.2 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m33.5/81.2 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m34.8/81.2 MB\u001b[0m \u001b[31m35.7 MB/s\u001b[0m eta \u001b[36m0:00:02\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m37.7/81.2 MB\u001b[0m \u001b[31m59.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m39.2/81.2 MB\u001b[0m \u001b[31m49.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.5/81.2 MB\u001b[0m \u001b[31m51.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.8/81.2 MB\u001b[0m \u001b[31m76.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.1/81.2 MB\u001b[0m \u001b[31m75.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -2776,10 +2825,135 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m129.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m21.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.1/81.2 MB\u001b[0m \u001b[31m75.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.9/81.2 MB\u001b[0m \u001b[31m43.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━\u001b[0m \u001b[32m50.9/81.2 MB\u001b[0m \u001b[31m52.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m54.9/81.2 MB\u001b[0m \u001b[31m53.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━\u001b[0m \u001b[32m59.5/81.2 MB\u001b[0m \u001b[31m104.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━\u001b[0m \u001b[32m64.0/81.2 MB\u001b[0m \u001b[31m118.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━\u001b[0m \u001b[32m65.0/81.2 MB\u001b[0m \u001b[31m105.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m67.1/81.2 MB\u001b[0m \u001b[31m82.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m69.3/81.2 MB\u001b[0m \u001b[31m70.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━\u001b[0m \u001b[32m73.6/81.2 MB\u001b[0m \u001b[31m69.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m77.6/81.2 MB\u001b[0m \u001b[31m104.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m80.7/81.2 MB\u001b[0m \u001b[31m109.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m81.2/81.2 MB\u001b[0m \u001b[31m5.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2788,7 +2962,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/73.5 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m73.5/73.5 kB\u001b[0m \u001b[31m17.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m73.5/73.5 kB\u001b[0m \u001b[31m18.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2797,9 +2971,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/7.7 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/7.7 MB\u001b[0m \u001b[31m123.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m135.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m86.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/7.7 MB\u001b[0m \u001b[31m123.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m124.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.7/7.7 MB\u001b[0m \u001b[31m87.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2808,7 +2982,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/206.9 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m206.9/206.9 kB\u001b[0m \u001b[31m42.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m206.9/206.9 kB\u001b[0m \u001b[31m47.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2817,7 +2991,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/98.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m98.3/98.3 kB\u001b[0m \u001b[31m28.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m98.3/98.3 kB\u001b[0m \u001b[31m21.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2826,9 +3000,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.0/8.9 MB\u001b[0m \u001b[31m166.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m168.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m99.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/8.9 MB\u001b[0m \u001b[31m124.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━\u001b[0m \u001b[32m8.6/8.9 MB\u001b[0m \u001b[31m123.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m93.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2837,7 +3011,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/130.2 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m130.2/130.2 kB\u001b[0m \u001b[31m32.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m130.2/130.2 kB\u001b[0m \u001b[31m31.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/7.0 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
      ]
     },
@@ -2846,11 +3020,12 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m4.9/7.0 MB\u001b[0m \u001b[31m149.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m150.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m93.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/117.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m117.7/117.7 kB\u001b[0m \u001b[31m31.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/7.0 MB\u001b[0m \u001b[31m154.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/7.0 MB\u001b[0m \u001b[31m154.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/7.0 MB\u001b[0m \u001b[31m154.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.0/7.0 MB\u001b[0m \u001b[31m21.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m40.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m36.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2858,10 +3033,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/42.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.8/42.8 kB\u001b[0m \u001b[31m9.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m90.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/117.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m117.7/117.7 kB\u001b[0m \u001b[31m33.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/42.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.8/42.8 kB\u001b[0m \u001b[31m10.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2869,9 +3044,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m101.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/92.9 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m92.9/92.9 kB\u001b[0m \u001b[31m28.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m92.9/92.9 kB\u001b[0m \u001b[31m30.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2880,9 +3070,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/45.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.7/45.7 kB\u001b[0m \u001b[31m10.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.7/45.7 kB\u001b[0m \u001b[31m13.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/59.5 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.5/59.5 kB\u001b[0m \u001b[31m15.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.5/59.5 kB\u001b[0m \u001b[31m17.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2890,9 +3080,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.2 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 kB\u001b[0m \u001b[31m15.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 kB\u001b[0m \u001b[31m14.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2901,7 +3097,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/86.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m86.0/86.0 kB\u001b[0m \u001b[31m27.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m86.0/86.0 kB\u001b[0m \u001b[31m28.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2917,10 +3113,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/12.3 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.2/12.3 MB\u001b[0m \u001b[31m185.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.2/12.3 MB\u001b[0m \u001b[31m184.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.2/12.3 MB\u001b[0m \u001b[31m184.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m100.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/12.3 MB\u001b[0m \u001b[31m106.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.1/12.3 MB\u001b[0m \u001b[31m103.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m10.5/12.3 MB\u001b[0m \u001b[31m110.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m97.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.3/12.3 MB\u001b[0m \u001b[31m76.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2929,7 +3126,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/67.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m67.0/67.0 kB\u001b[0m \u001b[31m18.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m67.0/67.0 kB\u001b[0m \u001b[31m22.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2938,9 +3135,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/58.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m16.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m16.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/341.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.4/341.4 kB\u001b[0m \u001b[31m49.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.4/341.4 kB\u001b[0m \u001b[31m64.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2949,16 +3146,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/3.4 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.4/3.4 MB\u001b[0m \u001b[31m103.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.3 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m99.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.4/3.4 MB\u001b[0m \u001b[31m109.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.3 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m54.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2967,10 +3157,12 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.7 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.7/1.7 MB\u001b[0m \u001b[31m97.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.7/1.7 MB\u001b[0m \u001b[31m101.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m19.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m17.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m16.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
      ]
     },
     {
@@ -2978,17 +3170,15 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.3/57.3 kB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.0/57.0 kB\u001b[0m \u001b[31m14.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.0/57.0 kB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/57.1 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.1/57.1 kB\u001b[0m \u001b[31m14.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.1/57.1 kB\u001b[0m \u001b[31m17.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.8/56.8 kB\u001b[0m \u001b[31m12.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.8/56.8 kB\u001b[0m \u001b[31m16.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.7/56.7 kB\u001b[0m \u001b[31m14.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.7/56.7 kB\u001b[0m \u001b[31m19.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m15.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m17.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -2997,23 +3187,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.4/8.9 MB\u001b[0m \u001b[31m163.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m131.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m85.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.6/8.9 MB\u001b[0m \u001b[31m140.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m156.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.5/8.9 MB\u001b[0m \u001b[31m103.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m7.3/8.9 MB\u001b[0m \u001b[31m107.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m86.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.4/8.9 MB\u001b[0m \u001b[31m164.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m163.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/8.9 MB\u001b[0m \u001b[31m151.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -3021,10 +3199,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m163.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m163.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m50.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.3/8.9 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m6.3/8.9 MB\u001b[0m \u001b[31m61.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m \u001b[32m8.7/8.9 MB\u001b[0m \u001b[31m62.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m54.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.4/8.9 MB\u001b[0m \u001b[31m131.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━\u001b[0m \u001b[32m7.4/8.9 MB\u001b[0m \u001b[31m107.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -3032,11 +3213,10 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.1/8.9 MB\u001b[0m \u001b[31m119.1 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━\u001b[0m \u001b[32m6.0/8.9 MB\u001b[0m \u001b[31m87.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m86.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/8.9 MB\u001b[0m \u001b[31m125.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m8.5/8.9 MB\u001b[0m \u001b[31m123.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -3044,25 +3224,12 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m98.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m14.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m93.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.5/8.9 MB\u001b[0m \u001b[31m44.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━\u001b[0m \u001b[32m5.9/8.9 MB\u001b[0m \u001b[31m85.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m96.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m77.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3071,31 +3238,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.8/8.9 MB\u001b[0m \u001b[31m144.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m155.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m97.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.9 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.5/8.9 MB\u001b[0m \u001b[31m106.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m \u001b[32m8.7/8.9 MB\u001b[0m \u001b[31m125.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.8/8.9 MB\u001b[0m \u001b[31m118.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m79.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/8.9 MB\u001b[0m \u001b[31m126.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━\u001b[0m \u001b[32m8.3/8.9 MB\u001b[0m \u001b[31m122.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.9/8.9 MB\u001b[0m \u001b[31m94.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/8.8 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/8.8 MB\u001b[0m \u001b[31m158.2 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m153.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/8.8 MB\u001b[0m \u001b[31m110.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m"
      ]
     },
     {
@@ -3103,13 +3250,23 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m97.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/8.8 MB\u001b[0m \u001b[31m77.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m6.3/8.8 MB\u001b[0m \u001b[31m80.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m66.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.8/8.8 MB\u001b[0m \u001b[31m57.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/56.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m14.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.4/56.4 kB\u001b[0m \u001b[31m14.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/55.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m55.4/55.4 kB\u001b[0m \u001b[31m16.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/54.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m54.8/54.8 kB\u001b[0m \u001b[31m15.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m55.4/55.4 kB\u001b[0m \u001b[31m14.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/54.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m54.8/54.8 kB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3118,7 +3275,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/341.8 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.8/341.8 kB\u001b[0m \u001b[31m60.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m341.8/341.8 kB\u001b[0m \u001b[31m56.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3127,7 +3284,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.6 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m94.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m90.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25h"
      ]
     },
@@ -3157,7 +3314,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "google-colab 1.0.0 requires pandas==1.5.3, but you have pandas 2.1.1 which is incompatible.\n",
+      "google-colab 1.0.0 requires pandas==1.5.3, but you have pandas 2.1.2 which is incompatible.\n",
       "tensorflow 2.13.0 requires typing-extensions<4.6.0,>=3.6.6, but you have typing-extensions 4.8.0 which is incompatible.\u001b[0m\u001b[31m\n",
       "\u001b[0m"
      ]
@@ -3171,20 +3328,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "31c6eb1a",
+   "id": "a581447e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:59:32.313106Z",
-     "iopub.status.busy": "2023-10-26T14:59:32.312565Z",
-     "iopub.status.idle": "2023-10-26T14:59:39.192314Z",
-     "shell.execute_reply": "2023-10-26T14:59:39.191067Z"
+     "iopub.execute_input": "2023-10-27T01:53:21.990259Z",
+     "iopub.status.busy": "2023-10-27T01:53:21.989908Z",
+     "iopub.status.idle": "2023-10-27T01:53:27.824325Z",
+     "shell.execute_reply": "2023-10-27T01:53:27.823186Z"
     },
     "id": "FksVuvkgLbpG",
     "papermill": {
-     "duration": 6.906813,
-     "end_time": "2023-10-26T14:59:39.194967",
+     "duration": 5.85871,
+     "end_time": "2023-10-27T01:53:27.826838",
      "exception": false,
-     "start_time": "2023-10-26T14:59:32.288154",
+     "start_time": "2023-10-27T01:53:21.968128",
      "status": "completed"
     },
     "tags": []
@@ -3201,14 +3358,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4d841e9",
+   "id": "ba95044b",
    "metadata": {
     "id": "-KttG3eOLlxg",
     "papermill": {
-     "duration": 0.022994,
-     "end_time": "2023-10-26T14:59:39.240719",
+     "duration": 0.022376,
+     "end_time": "2023-10-27T01:53:27.871880",
      "exception": false,
-     "start_time": "2023-10-26T14:59:39.217725",
+     "start_time": "2023-10-27T01:53:27.849504",
      "status": "completed"
     },
     "tags": []
@@ -3220,20 +3377,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "878986a9",
+   "id": "e15a30ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:59:39.287699Z",
-     "iopub.status.busy": "2023-10-26T14:59:39.286849Z",
-     "iopub.status.idle": "2023-10-26T14:59:42.093386Z",
-     "shell.execute_reply": "2023-10-26T14:59:42.092463Z"
+     "iopub.execute_input": "2023-10-27T01:53:27.915444Z",
+     "iopub.status.busy": "2023-10-27T01:53:27.914538Z",
+     "iopub.status.idle": "2023-10-27T01:53:30.893334Z",
+     "shell.execute_reply": "2023-10-27T01:53:30.892325Z"
     },
     "id": "dtNEiziLLlWv",
     "papermill": {
-     "duration": 2.83273,
-     "end_time": "2023-10-26T14:59:42.095822",
+     "duration": 3.003491,
+     "end_time": "2023-10-27T01:53:30.895627",
      "exception": false,
-     "start_time": "2023-10-26T14:59:39.263092",
+     "start_time": "2023-10-27T01:53:27.892136",
      "status": "completed"
     },
     "tags": []
@@ -3248,20 +3405,20 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "3ba13682",
+   "id": "59aee5fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:59:42.147282Z",
-     "iopub.status.busy": "2023-10-26T14:59:42.146640Z",
-     "iopub.status.idle": "2023-10-26T14:59:45.101190Z",
-     "shell.execute_reply": "2023-10-26T14:59:45.100170Z"
+     "iopub.execute_input": "2023-10-27T01:53:30.939904Z",
+     "iopub.status.busy": "2023-10-27T01:53:30.939557Z",
+     "iopub.status.idle": "2023-10-27T01:53:33.646122Z",
+     "shell.execute_reply": "2023-10-27T01:53:33.645255Z"
     },
     "id": "Rvf1sEizLwyR",
     "papermill": {
-     "duration": 2.984025,
-     "end_time": "2023-10-26T14:59:45.103829",
+     "duration": 2.730492,
+     "end_time": "2023-10-27T01:53:33.648354",
      "exception": false,
-     "start_time": "2023-10-26T14:59:42.119804",
+     "start_time": "2023-10-27T01:53:30.917862",
      "status": "completed"
     },
     "tags": []
@@ -3291,25 +3448,25 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "c133f819",
+   "id": "6fc3f54f",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 567
     },
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:59:45.159167Z",
-     "iopub.status.busy": "2023-10-26T14:59:45.158788Z",
-     "iopub.status.idle": "2023-10-26T14:59:49.017954Z",
-     "shell.execute_reply": "2023-10-26T14:59:49.017282Z"
+     "iopub.execute_input": "2023-10-27T01:53:33.692480Z",
+     "iopub.status.busy": "2023-10-27T01:53:33.692155Z",
+     "iopub.status.idle": "2023-10-27T01:53:37.098428Z",
+     "shell.execute_reply": "2023-10-27T01:53:37.097528Z"
     },
     "id": "tiA1Da5iLuid",
     "outputId": "09fcd200-9db3-4472-a0ce-0e39f7fcee79",
     "papermill": {
-     "duration": 3.887861,
-     "end_time": "2023-10-26T14:59:49.019584",
+     "duration": 3.430528,
+     "end_time": "2023-10-27T01:53:37.100429",
      "exception": false,
-     "start_time": "2023-10-26T14:59:45.131723",
+     "start_time": "2023-10-27T01:53:33.669901",
      "status": "completed"
     },
     "tags": []
@@ -3676,7 +3833,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"ea4fea73-df12-466f-8e19-e5c1e1569646\"></div>"
+       "<div id=\"653daa3c-4edb-410a-98e9-e9cb18ecfc8a\"></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -3692,14 +3849,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "499d85ac",
+   "id": "79454a58",
    "metadata": {
     "id": "_5LnamoiL6sf",
     "papermill": {
-     "duration": 0.025032,
-     "end_time": "2023-10-26T14:59:49.069261",
+     "duration": 0.022322,
+     "end_time": "2023-10-27T01:53:37.144908",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.044229",
+     "start_time": "2023-10-27T01:53:37.122586",
      "status": "completed"
     },
     "tags": []
@@ -3711,20 +3868,20 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "308375de",
+   "id": "c7dabfef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:59:49.116945Z",
-     "iopub.status.busy": "2023-10-26T14:59:49.116571Z",
-     "iopub.status.idle": "2023-10-26T14:59:49.121753Z",
-     "shell.execute_reply": "2023-10-26T14:59:49.120985Z"
+     "iopub.execute_input": "2023-10-27T01:53:37.190861Z",
+     "iopub.status.busy": "2023-10-27T01:53:37.190475Z",
+     "iopub.status.idle": "2023-10-27T01:53:37.196385Z",
+     "shell.execute_reply": "2023-10-27T01:53:37.195127Z"
     },
     "id": "sUi81pCUL5_0",
     "papermill": {
-     "duration": 0.031608,
-     "end_time": "2023-10-26T14:59:49.123565",
+     "duration": 0.031868,
+     "end_time": "2023-10-27T01:53:37.198389",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.091957",
+     "start_time": "2023-10-27T01:53:37.166521",
      "status": "completed"
     },
     "tags": []
@@ -3737,14 +3894,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32029414",
+   "id": "3e2c2913",
    "metadata": {
     "id": "QLfj3CutL5tV",
     "papermill": {
-     "duration": 0.02537,
-     "end_time": "2023-10-26T14:59:49.175895",
+     "duration": 0.022205,
+     "end_time": "2023-10-27T01:53:37.241599",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.150525",
+     "start_time": "2023-10-27T01:53:37.219394",
      "status": "completed"
     },
     "tags": []
@@ -3756,20 +3913,20 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "74532230",
+   "id": "465494f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-10-26T14:59:49.229505Z",
-     "iopub.status.busy": "2023-10-26T14:59:49.229099Z",
-     "iopub.status.idle": "2023-10-26T14:59:49.233957Z",
-     "shell.execute_reply": "2023-10-26T14:59:49.232883Z"
+     "iopub.execute_input": "2023-10-27T01:53:37.290412Z",
+     "iopub.status.busy": "2023-10-27T01:53:37.290043Z",
+     "iopub.status.idle": "2023-10-27T01:53:37.296771Z",
+     "shell.execute_reply": "2023-10-27T01:53:37.293642Z"
     },
     "id": "XSxs_YqeL6XW",
     "papermill": {
-     "duration": 0.035076,
-     "end_time": "2023-10-26T14:59:49.236422",
+     "duration": 0.035515,
+     "end_time": "2023-10-27T01:53:37.301169",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.201346",
+     "start_time": "2023-10-27T01:53:37.265654",
      "status": "completed"
     },
     "tags": []
@@ -3785,14 +3942,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bebb274d",
+   "id": "7b3be796",
    "metadata": {
     "id": "w1PIlmOkdfqd",
     "papermill": {
-     "duration": 0.025612,
-     "end_time": "2023-10-26T14:59:49.288336",
+     "duration": 0.022222,
+     "end_time": "2023-10-27T01:53:37.345159",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.262724",
+     "start_time": "2023-10-27T01:53:37.322937",
      "status": "completed"
     },
     "tags": []
@@ -3805,14 +3962,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59f53a2a",
+   "id": "5fe119f9",
    "metadata": {
     "id": "F1JKCw8IfYRE",
     "papermill": {
-     "duration": 0.023197,
-     "end_time": "2023-10-26T14:59:49.336068",
+     "duration": 0.021671,
+     "end_time": "2023-10-27T01:53:37.388377",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.312871",
+     "start_time": "2023-10-27T01:53:37.366706",
      "status": "completed"
     },
     "tags": []
@@ -3823,14 +3980,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a9b39bd",
+   "id": "9e61750f",
    "metadata": {
     "id": "gzMMpG4y6g-v",
     "papermill": {
-     "duration": 0.02308,
-     "end_time": "2023-10-26T14:59:49.382430",
+     "duration": 0.021077,
+     "end_time": "2023-10-27T01:53:37.430532",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.359350",
+     "start_time": "2023-10-27T01:53:37.409455",
      "status": "completed"
     },
     "tags": []
@@ -3843,14 +4000,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99c4266a",
+   "id": "d4969f36",
    "metadata": {
     "id": "NnuWgtK_vnWC",
     "papermill": {
-     "duration": 0.023156,
-     "end_time": "2023-10-26T14:59:49.428937",
+     "duration": 0.021625,
+     "end_time": "2023-10-27T01:53:37.473838",
      "exception": false,
-     "start_time": "2023-10-26T14:59:49.405781",
+     "start_time": "2023-10-27T01:53:37.452213",
      "status": "completed"
     },
     "tags": []
@@ -3891,20 +4048,20 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 99.252831,
-   "end_time": "2023-10-26T14:59:52.059819",
+   "duration": 99.512817,
+   "end_time": "2023-10-27T01:53:40.105122",
    "environment_variables": {},
    "exception": null,
    "input_path": "/content/notebooks/getting_started/part3_exploring_cohorts.ipynb",
    "output_path": "/content/test/outputs/part3_exploring_cohorts_papermill_output.ipynb",
    "parameters": {},
-   "start_time": "2023-10-26T14:58:12.806988",
+   "start_time": "2023-10-27T01:52:00.592305",
    "version": "2.4.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "0549823eeb6f4d97898b69fca874b267": {
+     "06cdc428d88d49fba69d55e554be65f3": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -3956,154 +4113,7 @@
        "width": null
       }
      },
-     "0e57b74da54a4baca1164821b7de8219": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_68bb0571bfb14082ba77efa783936d62",
-       "placeholder": "​",
-       "style": "IPY_MODEL_595f09c7b0eb4a93865b83aeb28058b4",
-       "value": ""
-      }
-     },
-     "23163ede7b1b4d999c56693f35aac4a9": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "3a109a7da2744da6ae3e51c39cfccc69": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "4b5176c49b1a4cb6a0bc2b0f95303d4a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_dd030c7f18694c4f8213e3cf2ad00ca9",
-        "IPY_MODEL_ac8453b987ba4e8795d22fdababda9eb",
-        "IPY_MODEL_c785f015f0b44120955b1b9137827aa4"
-       ],
-       "layout": "IPY_MODEL_3a109a7da2744da6ae3e51c39cfccc69"
-      }
-     },
-     "4ec60c395b6d48f68a2ad55fcde31f3c": {
+     "22783d6d75704df8bc2274720b715e6f": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -4118,7 +4128,7 @@
        "description_width": ""
       }
      },
-     "555230b97bcb4a88828eb439fda1cf45": {
+     "35053dd145f644f28092a68991ed24af": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -4170,126 +4180,23 @@
        "width": null
       }
      },
-     "595f09c7b0eb4a93865b83aeb28058b4": {
+     "45cfd8bc995441f6a0cff2f7bf14dc04": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
+      "model_name": "ProgressStyleModel",
       "state": {
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
+       "_model_name": "ProgressStyleModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "1.2.0",
        "_view_name": "StyleView",
+       "bar_color": null,
        "description_width": ""
       }
      },
-     "68bb0571bfb14082ba77efa783936d62": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "7e8cb147218e4f45b14f2d4aff522b05": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "9c8369ed2b8a46d0aba7ef3ad006e437": {
+     "5096f764cef5431cb69d81344da3355c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "FloatProgressModel",
@@ -4305,39 +4212,15 @@
        "bar_style": "success",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_dd2437e0c76e49348f79fd46427ba81f",
-       "max": 1.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_e8156d0ee08f41b9af428dabff102012",
-       "value": 1.0
-      }
-     },
-     "ac8453b987ba4e8795d22fdababda9eb": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_23163ede7b1b4d999c56693f35aac4a9",
+       "layout": "IPY_MODEL_dde29fec82a341edb68e580f1b5ff3f6",
        "max": 5.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_fd41ca331b304bed8df1dfeb3dbbd05c",
+       "style": "IPY_MODEL_7a9c1fcaf118486d927684794260e896",
        "value": 5.0
       }
      },
-     "b91a7d6f08a04a5d9ddcf5235d1084e7": {
+     "5834b1eabc8e42668e3f197867871888": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
@@ -4352,159 +4235,13 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_tooltip": null,
-       "layout": "IPY_MODEL_555230b97bcb4a88828eb439fda1cf45",
+       "layout": "IPY_MODEL_bf177ad4c52341749a93cf509bdb08a9",
        "placeholder": "​",
-       "style": "IPY_MODEL_e62fa4f454bc462b9157b1608bea2837",
-       "value": "Job ID 678199c3-0d8c-480d-9b26-725435ed8604 successfully executed: 100%"
-      }
-     },
-     "c785f015f0b44120955b1b9137827aa4": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_7e8cb147218e4f45b14f2d4aff522b05",
-       "placeholder": "​",
-       "style": "IPY_MODEL_fadac9766a9544c09ca175a4c1ba789d",
-       "value": ""
-      }
-     },
-     "dd030c7f18694c4f8213e3cf2ad00ca9": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_tooltip": null,
-       "layout": "IPY_MODEL_e47acd7aee434561b6d640fe472fc07d",
-       "placeholder": "​",
-       "style": "IPY_MODEL_4ec60c395b6d48f68a2ad55fcde31f3c",
+       "style": "IPY_MODEL_22783d6d75704df8bc2274720b715e6f",
        "value": "Downloading: 100%"
       }
      },
-     "dd2437e0c76e49348f79fd46427ba81f": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "e47acd7aee434561b6d640fe472fc07d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "e62fa4f454bc462b9157b1608bea2837": {
+     "6c8e6f332b71459daf671a1d974c2f79": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -4519,7 +4256,43 @@
        "description_width": ""
       }
      },
-     "e8156d0ee08f41b9af428dabff102012": {
+     "6f926c3efd704de080942702436f4881": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_bc996bae90204a90914251b520a95cec",
+       "placeholder": "​",
+       "style": "IPY_MODEL_a44f825bf272408f8d1984a596a847c0",
+       "value": ""
+      }
+     },
+     "779c9e56c22f42879bbaaac085e9d679": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "7a9c1fcaf118486d927684794260e896": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "ProgressStyleModel",
@@ -4535,7 +4308,126 @@
        "description_width": ""
       }
      },
-     "f9e382a5fc084d528800641362693cea": {
+     "9b62aed324da417a9ed1cffbc4dc8859": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9e11e2f11b624c59a04ac185c4273ed7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a44f825bf272408f8d1984a596a847c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "a561963e86f84c008f62d3a39e32f00a": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
@@ -4550,42 +4442,307 @@
        "_view_name": "HBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_b91a7d6f08a04a5d9ddcf5235d1084e7",
-        "IPY_MODEL_9c8369ed2b8a46d0aba7ef3ad006e437",
-        "IPY_MODEL_0e57b74da54a4baca1164821b7de8219"
+        "IPY_MODEL_5834b1eabc8e42668e3f197867871888",
+        "IPY_MODEL_5096f764cef5431cb69d81344da3355c",
+        "IPY_MODEL_e319bf1a5696472d9c07372a1326cf99"
        ],
-       "layout": "IPY_MODEL_0549823eeb6f4d97898b69fca874b267"
+       "layout": "IPY_MODEL_9e11e2f11b624c59a04ac185c4273ed7"
       }
      },
-     "fadac9766a9544c09ca175a4c1ba789d": {
+     "ac5beee8815948e1a620b75e769f17e0": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
+      "model_name": "HTMLModel",
       "state": {
+       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_b4ab03ce812c4553afa92324aa7ea4a2",
+       "placeholder": "​",
+       "style": "IPY_MODEL_779c9e56c22f42879bbaaac085e9d679",
+       "value": "Job ID bd45ae24-e976-41fd-8277-89dbb03704fa successfully executed: 100%"
+      }
+     },
+     "b4ab03ce812c4553afa92324aa7ea4a2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": ""
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
       }
      },
-     "fd41ca331b304bed8df1dfeb3dbbd05c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
+     "bc996bae90204a90914251b520a95cec": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
       "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "ProgressStyleModel",
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "bf177ad4c52341749a93cf509bdb08a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "dde29fec82a341edb68e580f1b5ff3f6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e319bf1a5696472d9c07372a1326cf99": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_35053dd145f644f28092a68991ed24af",
+       "placeholder": "​",
+       "style": "IPY_MODEL_6c8e6f332b71459daf671a1d974c2f79",
+       "value": ""
+      }
+     },
+     "eee5964fb92746e6bd9c578d1d613a1a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_9b62aed324da417a9ed1cffbc4dc8859",
+       "max": 1.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_45cfd8bc995441f6a0cff2f7bf14dc04",
+       "value": 1.0
+      }
+     },
+     "f7da54fe6529416c84eebc19eca68375": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_ac5beee8815948e1a620b75e769f17e0",
+        "IPY_MODEL_eee5964fb92746e6bd9c578d1d613a1a",
+        "IPY_MODEL_6f926c3efd704de080942702436f4881"
+       ],
+       "layout": "IPY_MODEL_06cdc428d88d49fba69d55e554be65f3"
       }
      }
     },


### PR DESCRIPTION
A few hours ago actions/setup-python@v4 was updated python version to 3.12 from 3.11.6. This led to pip installation error downstream. So, this PR addresses those deficiencies and locks python and pip package versions. 