### PR TITLE
Mark Slicer-desktop notebook as experimental; fix cross-references

### DIFF
--- a/notebooks/labs/image_visualization_with_slicer_desktop.ipynb
+++ b/notebooks/labs/image_visualization_with_slicer_desktop.ipynb
@@ -3,12 +3,34 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "<a href=\"https://colab.research.google.com/github/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/image_visualization_with_slicer_desktop.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   "source": "<a href=\"https://colab.research.google.com/github/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/labs/image_visualization_with_slicer_desktop.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Run the full 3D Slicer desktop application in Colab with IDC data\n\n---\n\n## Summary\n\nThis notebook shows how to run the **complete [3D Slicer](https://www.slicer.org) desktop\napplication** \u2014 the real, full graphical program, not just its rendering engine \u2014 **inside a Google\nColab cell**, and use it to interactively explore a radiology image and its segmentation downloaded\nfrom [NCI Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov).\n\n3D Slicer is normally a desktop app. Here we launch the genuine application *headlessly* on the Colab\nvirtual machine (software OpenGL rendering into a virtual X display) and **stream its live GUI into\nthe notebook** over a WebSocket video connection using the [**desktopia**](https://github.com/pieper/desktopia)\nproject. The result is the actual Slicer interface \u2014 menus, module panel, slice views, 3D view,\nmouse interaction \u2014 embedded in an output cell, with **no desktop install** on your machine.\n\nAs the example dataset we use the **same CT + segmentation** as the other IDC 3D-viewer tutorials\n([ipyniivue](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/image_visualization_with_ipyniivue.ipynb)\nand [trame-slicer](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/trame_slicer_visualization.ipynb)):\na low-dose chest CT from the [National Lung Screening Trial (NLST)](https://imaging.datacommons.cancer.gov/explore/?filters_for_load=collection_id_nlst)\ntogether with its whole-body multi-organ [TotalSegmentator](https://github.com/wasserth/TotalSegmentator)\nsegmentation, published in IDC as the `TotalSegmentator-CT-Segmentations` analysis result.\n\n**How this differs from the other two viewer tutorials**\n* **ipyniivue** embeds a WebGL viewer (NiiVue) and needs the data converted to NIfTI first.\n* **trame-slicer** embeds the 3D Slicer *rendering engine* through a custom trame web UI.\n* **This notebook** streams the *entire 3D Slicer desktop application itself* \u2014 you get every Slicer\n  module and the exact desktop UI, and Slicer loads the **DICOM image and DICOM SEG natively** (no\n  conversion needed).\n\nUpon completion of this tutorial you will learn how to:\n* set up a headless Slicer environment in Colab and install the [QuantitativeReporting](https://github.com/QIICR/QuantitativeReporting) extension (which lets Slicer read DICOM SEG)\n* download a DICOM image series and its DICOM Segmentation from IDC with [`idc-index`](https://github.com/ImagingDataCommons/idc-index)\n* launch the real 3D Slicer application headlessly, load the DICOM data, and build 3D organ surfaces\n* stream and interact with the live Slicer desktop directly inside a Colab cell\n\n> **Runtime note.** A standard **CPU** Colab runtime is sufficient \u2014 rendering uses software OpenGL\n> (Mesa/llvmpipe). The first two cells download ~400 MB (3D Slicer) and install system libraries, so\n> the initial setup takes a few minutes.\n\n> **Credit.** The headless-Slicer-in-Colab streaming setup used here is from Steve Pieper's\n> [desktopia](https://github.com/pieper/desktopia) project; this notebook adapts its\n> `desktopia_tcia_kidney` example to use IDC as the data source.\n\n---\nInitial version: Jun 2026\n\nUpdated: Jun 2026"
+   "source": [
+    "> # ⚠️ Experimental notebook — not actively supported\n",
+    ">\n",
+    "> **This notebook is an experimental proof-of-concept**, kept in `labs/` as a developer / community\n",
+    "> showcase. It is **not part of the supported IDC tutorial set** and **may break without notice**.\n",
+    ">\n",
+    "> It relies on fast-moving, unversioned components that are outside IDC's control, including:\n",
+    "> * the [**desktopia**](https://github.com/pieper/desktopia) streaming project, **cloned from a branch at runtime** (so any upstream change alters what this notebook runs);\n",
+    "> * Google Colab's internal port-proxying (`output.serve_kernel_port_as_iframe`), an undocumented API;\n",
+    "> * ~20 `apt` system packages and a software OpenGL stack; and\n",
+    "> * whatever the **current 3D Slicer release** happens to be at run time.\n",
+    ">\n",
+    "> **For a robust, supported way to view IDC images and segmentations interactively in Colab**, use the\n",
+    "> **ipyniivue** section of [Getting started — Part 2](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/getting_started/part2_searching_basics.ipynb),\n",
+    "> or the [**trame-slicer** tutorial](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/trame_slicer_visualization.ipynb)\n",
+    "> in `advanced_topics`. Use *this* notebook only if you specifically want to experiment with running\n",
+    "> the full Slicer desktop application in Colab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "# Run the full 3D Slicer desktop application in Colab with IDC data\n\n---\n\n## Summary\n\nThis notebook shows how to run the **complete [3D Slicer](https://www.slicer.org) desktop\napplication** — the real, full graphical program, not just its rendering engine — **inside a Google\nColab cell**, and use it to interactively explore a radiology image and its segmentation downloaded\nfrom [NCI Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov).\n\n3D Slicer is normally a desktop app. Here we launch the genuine application *headlessly* on the Colab\nvirtual machine (software OpenGL rendering into a virtual X display) and **stream its live GUI into\nthe notebook** over a WebSocket video connection using the [**desktopia**](https://github.com/pieper/desktopia)\nproject. The result is the actual Slicer interface — menus, module panel, slice views, 3D view,\nmouse interaction — embedded in an output cell, with **no desktop install** on your machine.\n\nAs the example dataset we use the **same CT + segmentation** as the other IDC 3D-viewer tutorials\n(the ipyniivue section of [Getting started — Part 2](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/getting_started/part2_searching_basics.ipynb)\nand [trame-slicer](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/trame_slicer_visualization.ipynb)):\na low-dose chest CT from the [National Lung Screening Trial (NLST)](https://imaging.datacommons.cancer.gov/explore/?filters_for_load=collection_id_nlst)\ntogether with its whole-body multi-organ [TotalSegmentator](https://github.com/wasserth/TotalSegmentator)\nsegmentation, published in IDC as the `TotalSegmentator-CT-Segmentations` analysis result.\n\n**How this differs from the other two viewer approaches**\n* **ipyniivue** embeds a WebGL viewer (NiiVue) and needs the data converted to NIfTI first.\n* **trame-slicer** embeds the 3D Slicer *rendering engine* through a custom trame web UI.\n* **This notebook** streams the *entire 3D Slicer desktop application itself* — you get every Slicer\n  module and the exact desktop UI, and Slicer loads the **DICOM image and DICOM SEG natively** (no\n  conversion needed).\n\nUpon completion of this tutorial you will learn how to:\n* set up a headless Slicer environment in Colab and install the [QuantitativeReporting](https://github.com/QIICR/QuantitativeReporting) extension (which lets Slicer read DICOM SEG)\n* download a DICOM image series and its DICOM Segmentation from IDC with [`idc-index`](https://github.com/ImagingDataCommons/idc-index)\n* launch the real 3D Slicer application headlessly, load the DICOM data, and build 3D organ surfaces\n* stream and interact with the live Slicer desktop directly inside a Colab cell\n\n> **Runtime note.** A standard **CPU** Colab runtime is sufficient — rendering uses software OpenGL\n> (Mesa/llvmpipe). The first two cells download ~400 MB (3D Slicer) and install system libraries, so\n> the initial setup takes a few minutes.\n\n> **Credit.** The headless-Slicer-in-Colab streaming setup used here is from Steve Pieper's\n> [desktopia](https://github.com/pieper/desktopia) project; this notebook adapts its\n> `desktopia_tcia_kidney` example to use IDC as the data source.\n\n---\nInitial version: Jun 2026\n\nUpdated: Jun 2026",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -37,7 +59,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 3. Download a CT and its segmentation from IDC\n\nWe use [`idc-index`](https://github.com/ImagingDataCommons/idc-index) to download the data directly\nfrom IDC \u2014 no TCIA / `tcia_utils` and no Google Cloud authentication required. For a fully\nreproducible demo we pin the **same** image + segmentation pair used in the ipyniivue and trame-slicer\ntutorials: a small NLST low-dose chest CT and its whole-body TotalSegmentator organ segmentation\n(both licensed CC BY 4.0).\n\nBoth series are downloaded with a *flat* layout (`dirTemplate=\"\"`) into one folder so that Slicer's\nDICOM importer can ingest the image and the SEG together."
+   "source": "## 3. Download a CT and its segmentation from IDC\n\nWe use [`idc-index`](https://github.com/ImagingDataCommons/idc-index) to download the data directly\nfrom IDC — no TCIA / `tcia_utils` and no Google Cloud authentication required. For a fully\nreproducible demo we pin the **same** image + segmentation pair used in the ipyniivue and trame-slicer\ntutorials: a small NLST low-dose chest CT and its whole-body TotalSegmentator organ segmentation\n(both licensed CC BY 4.0).\n\nBoth series are downloaded with a *flat* layout (`dirTemplate=\"\"`) into one folder so that Slicer's\nDICOM importer can ingest the image and the SEG together."
   },
   {
    "cell_type": "code",
@@ -49,7 +71,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 4. Launch 3D Slicer and load the data\n\nThis cell starts the real Slicer application on a virtual X display and runs a small startup script\n*inside* Slicer that:\n\n1. imports everything under `/content/idcDownload` into a temporary DICOM database and loads it \u2014\n   Slicer reads the CT series **and** the DICOM SEG natively (the SEG becomes a segmentation node);\n2. builds a **3D closed-surface representation** for every segment so the organs appear in the 3D view\n   (the TotalSegmentator SEG has dozens of structures, so this takes a few seconds);\n3. sets the four-up layout and frames the slice and 3D views.\n\ndesktopia then captures the GUI from the virtual display and serves it over a WebSocket video stream."
+   "source": "## 4. Launch 3D Slicer and load the data\n\nThis cell starts the real Slicer application on a virtual X display and runs a small startup script\n*inside* Slicer that:\n\n1. imports everything under `/content/idcDownload` into a temporary DICOM database and loads it —\n   Slicer reads the CT series **and** the DICOM SEG natively (the SEG becomes a segmentation node);\n2. builds a **3D closed-surface representation** for every segment so the organs appear in the 3D view\n   (the TotalSegmentator SEG has dozens of structures, so this takes a few seconds);\n3. sets the four-up layout and frames the slice and 3D views.\n\ndesktopia then captures the GUI from the virtual display and serves it over a WebSocket video stream."
   },
   {
    "cell_type": "code",
@@ -61,7 +83,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 5. View the live 3D Slicer desktop\n\nRun the cell below to embed the streamed Slicer GUI in the notebook. Give it a few seconds to connect\nand for the CT + segmentation to finish loading, then interact directly:\n\n* **scroll** in a slice view to page through slices;\n* **left-drag** in the 3D view to rotate, **scroll** to zoom;\n* use the **module panel** on the left exactly as in desktop Slicer \u2014 every Slicer module is available\n  (try *Segmentations*, *Volume Rendering*, or *Data*).\n\n> If the view is blank, re-run this cell (the stream may still have been starting), or re-run the\n> previous cell to relaunch Slicer."
+   "source": "## 5. View the live 3D Slicer desktop\n\nRun the cell below to embed the streamed Slicer GUI in the notebook. Give it a few seconds to connect\nand for the CT + segmentation to finish loading, then interact directly:\n\n* **scroll** in a slice view to page through slices;\n* **left-drag** in the 3D view to rotate, **scroll** to zoom;\n* use the **module panel** on the left exactly as in desktop Slicer — every Slicer module is available\n  (try *Segmentations*, *Volume Rendering*, or *Data*).\n\n> If the view is blank, re-run this cell (the stream may still have been starting), or re-run the\n> previous cell to relaunch Slicer."
   },
   {
    "cell_type": "code",
@@ -73,19 +95,22 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 6. Cite the data you used\n\nMost IDC data (including this collection) is licensed CC BY 4.0, which permits commercial use **with\nattribution**. `idc-index` generates ready-to-use citations for any selection \u2014 here both the NLST\nimages and the TotalSegmentator analysis result."
+   "source": "## 6. Cite the data you used\n\nMost IDC data (including this collection) is licensed CC BY 4.0, which permits commercial use **with\nattribution**. `idc-index` generates ready-to-use citations for any selection — here both the NLST\nimages and the TotalSegmentator analysis result."
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "source": "for citation in client.citations_from_selection(seriesInstanceUID=[ct_series, seg_series]):\n    print(citation, \"\\n\")"
+   "source": [
+    "for citation in client.citations_from_selection(seriesInstanceUID=[ct_series, seg_series]):\n",
+    "    print(citation, \"\\n\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Next steps\n\n* **Use the full Slicer app.** Because this is the complete 3D Slicer desktop, you can do anything\n  Slicer supports \u2014 edit the segmentation in *Segment Editor*, tune *Volume Rendering*, take\n  measurements, or run other extensions.\n* **Swap in different data.** The download in Section 3 works for any IDC series; change `ct_series`\n  / `seg_series` to any image (CT, MR, PT, ...) and any DICOM SEG. Browse collections in the\n  [IDC Portal](https://portal.imaging.datacommons.cancer.gov/explore/). Drop the segmentation to view\n  an image alone.\n* **Prefer a lighter-weight embedded viewer?** See the companion tutorials that render inside the cell\n  without streaming a full desktop:\n  [ipyniivue](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/image_visualization_with_ipyniivue.ipynb)\n  (WebGL widget) and\n  [trame-slicer](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/trame_slicer_visualization.ipynb)\n  (Slicer rendering engine via trame).\n* More tutorials are in the [IDC-Tutorials repository](https://github.com/ImagingDataCommons/IDC-Tutorials)."
+   "source": "## Next steps\n\n* **Use the full Slicer app.** Because this is the complete 3D Slicer desktop, you can do anything\n  Slicer supports — edit the segmentation in *Segment Editor*, tune *Volume Rendering*, take\n  measurements, or run other extensions.\n* **Swap in different data.** The download in Section 3 works for any IDC series; change `ct_series`\n  / `seg_series` to any image (CT, MR, PT, ...) and any DICOM SEG. Browse collections in the\n  [IDC Portal](https://portal.imaging.datacommons.cancer.gov/explore/). Drop the segmentation to view\n  an image alone.\n* **Prefer a robust, supported embedded viewer?** See the companion tutorials that render inside the\n  cell without streaming a full desktop: the **ipyniivue** section of\n  [Getting started — Part 2](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/getting_started/part2_searching_basics.ipynb)\n  (WebGL widget) and\n  [trame-slicer](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/advanced_topics/trame_slicer_visualization.ipynb)\n  (Slicer rendering engine via trame).\n* More tutorials are in the [IDC-Tutorials repository](https://github.com/ImagingDataCommons/IDC-Tutorials)."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Follow-up tweaks to the `labs/image_visualization_with_slicer_desktop.ipynb` notebook (added in #104).

- **Add an "experimental — not actively supported" banner** at the top, explaining the notebook is a `labs/` proof-of-concept that depends on fast-moving, unversioned components (the desktopia branch clone, Colab's undocumented `output.serve_kernel_port_as_iframe`, ~20 `apt` packages, and whatever the current 3D Slicer release is) and may break without notice. It points users to the supported alternatives.
- **Redirect ipyniivue references** to the ipyniivue section of [Getting started — Part 2](https://github.com/ImagingDataCommons/IDC-Tutorials/blob/master/notebooks/getting_started/part2_searching_basics.ipynb), since the standalone ipyniivue notebook was folded into Part 2 on master.
- **Fix the Colab badge URL** to the `labs/` path matching the file's actual location.
- Minor wording tweaks and removal of stray `execution_count`/`outputs` keys that a markdown cell had picked up.

Only the one notebook is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)